### PR TITLE
Tmarble/add travis integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: java
+before_install:
+- git clone https://github.com/DEX-Company/surfer.git
+- ./surfer/test/bin/cli-test startup
 install: true
 addons:
   ssh_known_hosts: shrimp.octet.services
 script:
-- mvn install
+- mvn integration:test
+after_script:
+- ./surfer/test/bin/cli-test shutdown
 after_success:
 - ./scripts/deployDocs.sh shrimp.octet.services docs_deploy dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install: true
 addons:
   ssh_known_hosts: shrimp.octet.services
 script:
-- mvn integration:test
+- mvn integration-test
 # after_script:
 # - ./surfer/test/bin/cli-test shutdown
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: java
-before_install:
-- git clone https://github.com/DEX-Company/surfer.git
-- ./surfer/test/bin/cli-test startup
+# NOTE this will not work while surfer is private
+# before_install:
+# - git clone https://github.com/DEX-Company/surfer.git
+# - ./surfer/test/bin/cli-test startup
 install: true
 addons:
   ssh_known_hosts: shrimp.octet.services
 script:
 - mvn integration:test
-after_script:
-- ./surfer/test/bin/cli-test shutdown
+# after_script:
+# - ./surfer/test/bin/cli-test shutdown
 after_success:
 - ./scripts/deployDocs.sh shrimp.octet.services docs_deploy dev

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,37 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.0</version>
+                                <configuration>
+                                  <includes>
+                                    <include>**/Test**.java</include>
+                                    <include>**/ParamTest**.java</include>
+                                  </includes>
+                                  <excludes>
+                                    <exclude>**/*IntegrationTests.java</exclude>
+                                  </excludes>
+                                </configuration>
+                                <executions>
+                                  <execution>
+                                    <id>integration-test</id>
+                                    <goals>
+                                      <goal>test</goal>
+                                    </goals>
+                                    <phase>integration-test</phase>
+                                    <configuration>
+                                      <excludes>
+                                        <exclude>none</exclude>
+                                      </excludes>
+                                      <includes>
+                                        <include>**/*IntegrationTests.java</include>
+                                      </includes>
+                                    </configuration>
+                                  </execution>
+                                </executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
 				<version>3.7.1</version>
 			</plugin>

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
@@ -481,4 +481,30 @@ public class RemoteAgent extends AAgent implements Invokable {
 		throw new RuntimeException("Invoke request failed with code " + statusCode + ": " + reason);
 	}
 
+	public static boolean isAgentUp(String uri) {
+		Boolean up = false;
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		HttpGet httpGet = new HttpGet(uri);
+		httpGet.setHeader("Authorization", "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+		CloseableHttpResponse response;
+		try {
+			response = httpclient.execute(httpGet);
+			try {
+				StatusLine statusLine = response.getStatusLine();
+				int statusCode = statusLine.getStatusCode();
+				if (statusCode == 200) {
+					up = true;
+				}
+			}
+			finally {
+				response.close();
+			}
+		}
+		catch (ClientProtocolException e) {
+		}
+		catch (IOException e) {
+		}
+		return up;
+	}
+
 }

--- a/src/test/java/sg/dex/starfish/samples/InvokeSample.java
+++ b/src/test/java/sg/dex/starfish/samples/InvokeSample.java
@@ -8,7 +8,7 @@ public class InvokeSample {
 
 
 	public static void main(String... args) {
-		
+
 		Operation op = ReverseBytesOperation.create();
 		System.out.println(JSON.toPrettyString(op.getMetadata()));
 	}

--- a/src/test/java/sg/dex/starfish/samples/IrisSample.java
+++ b/src/test/java/sg/dex/starfish/samples/IrisSample.java
@@ -11,12 +11,12 @@ public class IrisSample {
 		RemoteAgent surfer = SurferConfig.getSurfer("http://localhost:8080");
 
 		ResourceAsset iris=ResourceAsset.create("assets/iris.csv");
-		
+
 		String prettyJSON = JSON.toPrettyString(iris.getMetadata());
 		System.out.println(Utils.stringFromStream(iris.getInputStream()));
-		System.out.println("ID = "+iris.getAssetID());
+		System.out.println("Asset ID = "+iris.getAssetID());
 		System.out.println(prettyJSON);
-		
+
 		surfer.registerAsset(iris);
 	}
 

--- a/src/test/java/sg/dex/starfish/samples/MetadataSample.java
+++ b/src/test/java/sg/dex/starfish/samples/MetadataSample.java
@@ -1,6 +1,7 @@
 package sg.dex.starfish.samples;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import sg.dex.starfish.Asset;
 import sg.dex.starfish.impl.remote.RemoteAgent;
@@ -8,9 +9,23 @@ import sg.dex.starfish.impl.remote.RemoteAgent;
 public class MetadataSample {
 
 	public static void main(String... args) {
+		String assetID = null;
+		String defaultAssetID = "69ea9dcb1f9fdbdb803e91d735bdc56b76f7a0130d4a9615955438afda5eb393";
+
+		if (args.length > 0) {
+			assetID = args[0];
+		}
+		if (assetID == null) {
+			assetID = defaultAssetID;
+		}
+		System.out.println("looking up assetID = "+assetID);
 		RemoteAgent surfer = SurferConfig.getSurfer("http://localhost:8080");
-		Asset a=surfer.getAsset("69ea9dcb1f9fdbdb803e91d735bdc56b76f7a0130d4a9615955438afda5eb393");
-		assertEquals("{\"name\":\"My Test Asset\"}",a.getMetadataString());
+		Asset a=surfer.getAsset(assetID);
+		if (assetID == defaultAssetID) {
+			assertEquals("{\"name\":\"My Test Asset\"}",a.getMetadataString());
+		} else {
+			assertTrue(a.getMetadataString().length() > 11);
+		}
 	}
 
 

--- a/src/test/java/sg/dex/starfish/samples/RegisterSample.java
+++ b/src/test/java/sg/dex/starfish/samples/RegisterSample.java
@@ -9,24 +9,30 @@ import sg.dex.starfish.util.JSON;
 
 public class RegisterSample {
 
-	public static void main(String... args) {
+	public static String test(String... args) {
 		RemoteAgent surfer = SurferConfig.getSurfer("http://localhost:8080");
-		
+
 		// a new memory asset
 		Asset a=MemoryAsset.create("Hello World");
-		System.out.println("Asset ID: "+a.getAssetID());
+		String assetID = a.getAssetID();
+		System.out.println("Asset ID: "+assetID);
 		String prettyJSON = JSON.toPrettyString(a.getMetadata());
 		System.out.println(prettyJSON);
-		
+
 		Asset ra=surfer.registerAsset(a);
-		
+
 		// check the metadata is correct
 		assertEquals(a.getMetadata(),ra.getMetadata());
-		
-		
-		// download the asset 
+
+
+		// download the asset
 		// Asset dl=MemoryAsset.create(ra);
+
+		return assetID;
 	}
 
+	public static void main(String... args) {
+		test(args);
+	}
 
 }

--- a/src/test/java/sg/dex/starfish/samples/SampleIntegrationTests.java
+++ b/src/test/java/sg/dex/starfish/samples/SampleIntegrationTests.java
@@ -1,0 +1,34 @@
+package sg.dex.starfish.samples;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SampleIntegrationTests {
+	private static String registerAssetID = null;
+
+	@Test public void aTestInvokeSample() {
+		System.out.println("=== aTestInvokeSample ===");
+		InvokeSample.main();
+	}
+
+	@Test public void bTestIrisSample() {
+		System.out.println("=== bTestIrisSample ===");
+		IrisSample.main();
+	}
+
+	@Test public void cTestRegisterSample() {
+		System.out.println("=== cTestRegisterSample ===");
+		registerAssetID = RegisterSample.test();
+	}
+
+	@Test public void dTestMetadataSample() {
+		System.out.println("=== dTestMetadataSample ===");
+		MetadataSample.main(registerAssetID);
+	}
+
+}

--- a/src/test/java/sg/dex/starfish/samples/SampleIntegrationTests.java
+++ b/src/test/java/sg/dex/starfish/samples/SampleIntegrationTests.java
@@ -1,5 +1,7 @@
 package sg.dex.starfish.samples;
 
+import sg.dex.starfish.impl.remote.RemoteAgent;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -9,6 +11,7 @@ import org.junit.runners.MethodSorters;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SampleIntegrationTests {
+	private static boolean surferUp = RemoteAgent.isAgentUp("http://localhost:8080");
 	private static String registerAssetID = null;
 
 	@Test public void aTestInvokeSample() {
@@ -18,17 +21,29 @@ public class SampleIntegrationTests {
 
 	@Test public void bTestIrisSample() {
 		System.out.println("=== bTestIrisSample ===");
-		IrisSample.main();
+		if (surferUp) {
+			IrisSample.main();
+		} else {
+			System.out.println("WARNING: not tested as surfer is not up.");
+		}
 	}
 
 	@Test public void cTestRegisterSample() {
 		System.out.println("=== cTestRegisterSample ===");
-		registerAssetID = RegisterSample.test();
+		if (surferUp) {
+			registerAssetID = RegisterSample.test();
+		} else {
+			System.out.println("WARNING: not tested as surfer is not up.");
+		}
 	}
 
 	@Test public void dTestMetadataSample() {
 		System.out.println("=== dTestMetadataSample ===");
-		MetadataSample.main(registerAssetID);
+		if (surferUp) {
+			MetadataSample.main(registerAssetID);
+		} else {
+			System.out.println("WARNING: not tested as surfer is not up.");
+		}
 	}
 
 }

--- a/src/test/java/sg/dex/starfish/samples/SurferConfig.java
+++ b/src/test/java/sg/dex/starfish/samples/SurferConfig.java
@@ -31,11 +31,11 @@ public class SurferConfig {
 		String ddoString=JSON.toPrettyString(ddo);
 		// System.out.println(ddoString);
 		Map<String,Object> surferDDO=JSON.toMap(ddoString);
-		
+
 		Ocean ocean=Ocean.connect();
 		DID surferDID=DID.createRandom();
 		ocean.registerLocalDID(surferDID,ddoString);
-		
+
 		RemoteAgent surfer=RemoteAgent.create(ocean,surferDID);
 		assertEquals(surferDID,surfer.getDID());
 		assertEquals(surferDDO,surfer.getDDO());

--- a/src/test/java/sg/dex/starfish/util/UtilsSuite.java
+++ b/src/test/java/sg/dex/starfish/util/UtilsSuite.java
@@ -3,12 +3,14 @@ package sg.dex.starfish.util;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-@RunWith(Suite.class)				
-@Suite.SuiteClasses({				
-	  TestHex.class,
-	  TestUtils.class,
-	  TestDID.class
-})		
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	ParamTestJSON.class,
+	TestDID.class,
+  	TestHex.class,
+	TestJSON.class,
+	TestUtils.class
+})
 public class UtilsSuite {
 
 }


### PR DESCRIPTION
Adds surefire plugin to separate out `mvn test` and `mvn integration-test`
- also ensures ParamTestJSON is run with unit tests (i.e. `mvn-test`)

Adapts Travis to run `mvn integration-test`
- _NOTE:_ we cannot run integration tests depending on surfer in Travis right now because it's private.
- Adds RemoteAgent.isAgentUp()
- See example Travis log here: https://travis-ci.com/DEX-Company/starfish-java/builds/102885897