### PR TITLE
Ensure failing Javadoc generation does not make Travis fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,16 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.0.1</version>
 				<configuration>
-					<show>public</show>
+				  <show>public</show>
+                                  <failOnError>
+                                    false
+                                  </failOnError>
+                                  <failOnWarnings>
+                                    false
+                                  </failOnWarnings>
+                                  <doclint>
+                                    all,-missing
+                                  </doclint>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -89,10 +89,10 @@
 				<configuration>
 				  <show>public</show>
                                   <failOnError>
-                                    false
+                                    true
                                   </failOnError>
                                   <failOnWarnings>
-                                    false
+                                    true
                                   </failOnWarnings>
                                   <doclint>
                                     all,-missing

--- a/scripts/deployDocs.sh
+++ b/scripts/deployDocs.sh
@@ -31,7 +31,11 @@ echo "building docs package $PACKAGE_NAME"
 
 # make the docs from source
 rm -rf target/site
-mvn site
+if mvn site ; then
+    echo "Built Javadocs successfully"
+else
+    echo "FAILED building Javadocs"
+fi
 
 # package into a tar.gz file for deployment
 (cd "$DOC_PATH"; tar -czf "../../$DEPLOY_FILENAME" ./)

--- a/src/main/java/sg/dex/starfish/Identity.java
+++ b/src/main/java/sg/dex/starfish/Identity.java
@@ -19,7 +19,7 @@ public interface Identity {
 	/**
 	 * Gets the Accounts associated with this Identity
 	 * where the key is the Account.getID();
-	 * @return
+	 * @return hashmap of Accounts
 	 */
 	public Map<String,Account> getAccounts();
 

--- a/src/main/java/sg/dex/starfish/Listing.java
+++ b/src/main/java/sg/dex/starfish/Listing.java
@@ -44,8 +44,8 @@ public interface Listing {
 
 	/**
 	 * Purchases this listing using the given account
-	 * @param a The account to use for the purchase
-	 * @return
+	 * @param account The account to use for the purchase
+	 * @return PLEASE EXPLAIN the Object returned
 	 */
 	public Object purchase(Account account);
 }

--- a/src/main/java/sg/dex/starfish/impl/AIdentity.java
+++ b/src/main/java/sg/dex/starfish/impl/AIdentity.java
@@ -40,7 +40,7 @@ public abstract class AIdentity implements Identity {
 	/**
 	 * Gets the Accounts associated with this Identity
 	 * where the key is the Account.getID();
-	 * @return
+	 * @return hashmap of Accounts
 	 */
 	@Override
 	public Map<String,Account> getAccounts() {

--- a/src/main/java/sg/dex/starfish/impl/file/FileAsset.java
+++ b/src/main/java/sg/dex/starfish/impl/file/FileAsset.java
@@ -33,18 +33,18 @@ public class FileAsset extends ADataAsset {
 
 	/**
 	 * Create a FileAsset to read from an existing file
-	 * @param f
-	 * @return
+	 * @param f File from which to read the Asset
+	 * @return FileAsset
 	 */
 	public static FileAsset create(File f) {
 		return new FileAsset(buildMetadata(f,null),f);
 	}
-	
+
 	/**
 	 * Create a new FileAsset at the given file location, using the specified asset as a source.
-	 * @param f
-	 * @param source
-	 * @return
+	 * @param f File from which to read the Asset
+	 * @param source Asset
+	 * @return FileAsset
 	 */
 	public static FileAsset create(File f, Asset source) {
 		throw new TODOException("Create file asset on disk");

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteHttpAsset.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteHttpAsset.java
@@ -26,7 +26,7 @@ public class RemoteHttpAsset extends ADataAsset {
     /**
      * API to get the content of data with give url passes in param
      * @param urlString url where the content has to be read
-     * @return
+     * @return Asset
      */
     public static Asset createWithURL(String urlString) {
         URL url;
@@ -55,8 +55,8 @@ public class RemoteHttpAsset extends ADataAsset {
 
     /**
      * API to create the Local Resource Asset with a given remote Asset path .
-     * @param urlString
-     * @return
+     * @param urlString remote Asset Path
+     * @return Asset
      */
     public static Asset createResourceWithURL(String urlString ){
 

--- a/src/main/java/sg/dex/starfish/impl/squid/SquidAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/squid/SquidAgent.java
@@ -45,7 +45,7 @@ public class SquidAgent extends AAgent {
 	/**
 	 * Creates a RemoteAgent with the specified OceanAPI, Ocean connection and DID
 	 *
-	 * @param oceanapi Squid OceanAPI to use
+	 * @param oceanAPI Squid OceanAPI to use
 	 * @param ocean Ocean connection to use
 	 * @param did DID for this agent
 	 * @return RemoteAgent

--- a/src/main/java/sg/dex/starfish/util/Utils.java
+++ b/src/main/java/sg/dex/starfish/util/Utils.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 /**
  * Utility class for StarFish
- * 
+ *
  * @author Mike
  *
  */
@@ -25,7 +25,7 @@ public class Utils {
 
 	/**
 	 * Creates a random hex string of the specified length
-	 * 
+	 *
 	 * @param length Number of bytes of hex data to create
 	 * @return A lowercase hex string of the specified length
 	 */
@@ -38,7 +38,7 @@ public class Utils {
 
 	/**
 	 * Compares two objects for equality. null is considered equal to null.
-	 * 
+	 *
 	 * @param a First object
 	 * @param b Second object
 	 * @return boolean true if the arguments are equal, false otherwise
@@ -50,7 +50,7 @@ public class Utils {
 
 	/**
 	 * Computes the hashcode for an Object. returns zero for null.
-	 * 
+	 *
 	 * @param o Object for which to compute the hashcode
 	 * @return The computed hashcode
 	 */
@@ -141,7 +141,7 @@ public class Utils {
 
 	/**
 	 * Creates a map using the given arguments as keys and values
-	 * 
+	 *
 	 * @param params A sequence of (key,value) objects
 	 * @throws IllegalArgumentException if mapOf has odd number of arguments
 	 * @return A map containing the key keys and values
@@ -176,7 +176,7 @@ public class Utils {
 	 * Checks HTTP URL and returns <code>true</code> a connection can be established
 	 * to the corresponding host and port
 	 *
-	 * @param url The HTTP URL to be checked.
+	 * @param urlString The HTTP URL to be checked.
 	 * @return boolean if endpoint is up within the timeout
 	 */
 	public static boolean checkURL(String urlString) {


### PR DESCRIPTION
Turns on consistent maven-javadoc-plugin configuration
while printing Javadoc generation status from scripts/deployDocs.sh

NOTE: Javadoc errors are left in _ON PURPOSE_ for this PR build to demonstrate that Travis succeeds.