### PR TITLE
Adds dependency pins to avoid conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,71 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+        <dependencyManagement>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.httpcomponents</groupId>
+              <artifactId>httpclient</artifactId>
+              <version>4.5.7</version>
+            </dependency>
+            <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <version>2.9.8</version>
+            </dependency>
+            <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-core</artifactId>
+              <version>2.9.8</version>
+            </dependency>
+            <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+              <version>2.9.8</version>
+            </dependency>
+            <dependency>
+              <groupId>net.i2p.crypto</groupId>
+              <artifactId>eddsa</artifactId>
+              <version>0.3.0</version>
+            </dependency>
+            <dependency>
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+              <version>4.12</version>
+            </dependency>
+            <dependency>
+              <groupId>com.google.api-client</groupId>
+              <artifactId>google-api-client</artifactId>
+              <version>1.26.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.bouncycastle</groupId>
+              <artifactId>bcprov-jdk15on</artifactId>
+              <version>1.61</version>
+            </dependency>
+            <dependency>
+              <groupId>com.google.code.gson</groupId>
+              <artifactId>gson</artifactId>
+              <version>2.8.5</version>
+            </dependency>
+            <dependency>
+              <groupId>com.github.jnr</groupId>
+              <artifactId>jnr-ffi</artifactId>
+              <version>2.1.2</version>
+            </dependency>
+            <dependency>
+              <groupId>commons-codec</groupId>
+              <artifactId>commons-codec</artifactId>
+              <version>1.11</version>
+            </dependency>
+            <dependency>
+              <groupId>commons-logging</groupId>
+              <artifactId>commons-logging</artifactId>
+              <version>1.2</version>
+            </dependency>
+          </dependencies>
+        </dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
@@ -141,6 +206,14 @@
 				<artifactId>maven-project-info-reports-plugin</artifactId>
 				<version>3.0.0</version>
 			</plugin>
+			<plugin>
+                          <groupId>org.apache.maven.plugins</groupId>
+                          <artifactId>maven-enforcer-plugin</artifactId>
+                          <version>3.0.0-M2</version>
+                          <configuration>
+                            <rules><dependencyConvergence/></rules>
+                          </configuration>
+                        </plugin>
 		</plugins>
 
 		<resources>


### PR DESCRIPTION
Several of the transitive dependencies were ambiguous
Adds the maven-enforcer-plugin to detect and remedy ambiguities.

Workflow:
1. Find ambiguities
`mvn enforcer:enforce`
2. If not clean, add dependency pins(s) and try again
```
        <dependencyManagement>
          <dependencies>
            <dependency>
              <groupId>org.apache.httpcomponents</groupId>
              <artifactId>httpclient</artifactId>
              <version>4.5.7</version>
            </dependency>
        ...
```
3. Show resolved dependencies
`mvn dependency:tree -B`

NOTE:
Many of the ambiguities are inhertied from squid-java -- if that
version should change these pins will need to be recalculated.

FFI:
https://dzone.com/articles/solving-dependency-conflicts-in-maven
https://stackoverflow.com/questions/7175398/maven-dependency-resolution-conflicted

Signed-off-by: Tom Marble <tmarble@info9.net>