### PR TITLE
Adds structure to abstract authentication

### DIFF
--- a/src/main/java/sg/dex/starfish/impl/AAccount.java
+++ b/src/main/java/sg/dex/starfish/impl/AAccount.java
@@ -28,7 +28,7 @@ public abstract class AAccount implements Account {
 
 	protected AAccount(String id, Map<String, Object> credentials) {
 		this.id=id;
-		this.credentials = credentials;;
+		this.credentials = (credentials == null) ? new HashMap<String,Object>() : credentials;
 	}
 
 	/**
@@ -51,7 +51,7 @@ public abstract class AAccount implements Account {
 	 */
         @Override
 	public Map<String,Object> getCredentials() {
-           // deep cloning the map
+		// deep cloning the map
 		return  credentials.entrySet().stream()
 			.collect(Collectors.toMap(e -> e.getKey(),
 						  e -> e.getValue()));

--- a/src/main/java/sg/dex/starfish/impl/AAccount.java
+++ b/src/main/java/sg/dex/starfish/impl/AAccount.java
@@ -1,6 +1,10 @@
 package sg.dex.starfish.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import sg.dex.starfish.Account;
+
 
 /**
  * Class representing an Account in the Ocean Ecosystem
@@ -11,6 +15,7 @@ import sg.dex.starfish.Account;
 public abstract class AAccount implements Account {
 
 	protected String id;
+	private Map<String, Object> credentials;
 
 	/**
 	 * Create an AAccount with the provided ID
@@ -19,6 +24,7 @@ public abstract class AAccount implements Account {
 	 */
 	protected AAccount(String id) {
 		this.id=id;
+		this.credentials = new HashMap<String,Object>();
 	}
 
 	/**
@@ -29,5 +35,37 @@ public abstract class AAccount implements Account {
 	@Override
 	public String getID() {
 		return id;
+	}
+
+	/**
+	 * Gets the credentials stored for this Account.
+	 *
+	 * Required credentials are defined by the agent implementation, but would typically include
+	 * things like user name, password etc.
+	 *
+	 * @return
+	 */
+	public Map<String,Object> getCredentials() {
+		return this.credentials;
+	}
+
+	public void setCredential(String key, Object value) {
+		credentials.put(key, value);
+	}
+
+	public String toString() {
+		final StringBuilder tmp = new StringBuilder();
+		tmp.append(this.getClass().getName());
+		tmp.append(":");
+		tmp.append(this.id);
+		tmp.append("{");
+		for (Map.Entry<String, Object> entry : credentials.entrySet()) {
+			tmp.append(entry.getKey());
+			tmp.append("=");
+			tmp.append(entry.getValue().toString());
+			tmp.append(",");
+		}
+		tmp.append("}");
+		return tmp.toString();
 	}
 }

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAccount.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAccount.java
@@ -1,0 +1,24 @@
+package sg.dex.starfish.impl.remote;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import sg.dex.starfish.impl.AAccount;
+
+/**
+ * Class representing a RemoteAccount in the Ocean Ecosystem
+ *
+ * @author Tom
+ *
+ */
+public class RemoteAccount extends AAccount {
+
+	/**
+	 * Create an RemoteAccount with the provided ID
+	 *
+	 * @param id The identifier for this account
+	 */
+	protected RemoteAccount(String id) {
+		super(id);
+	}
+}

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAccount.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAccount.java
@@ -12,26 +12,41 @@ import java.util.Map;
 public class RemoteAccount extends AAccount {
 
 
-    private Map<String, Object> userDataMap;
+	private Map<String, Object> userDataMap;
 
-    /**
-     * Create an AAccount with the provided ID
-     *
-     * @param id The identifier for this account
-     */
-    protected RemoteAccount(String id, Map<String, Object> credentials) {
-        super(id, credentials);
-        userDataMap = new HashMap<>();
-    }
+	/**
+	 * Create an AAccount with the provided ID
+	 *
+	 * @param id The identifier for this account
+	 */
+	protected RemoteAccount(String id, Map<String, Object> credentials) {
+		super(id, credentials);
+		userDataMap = new HashMap<>();
+	}
 
-    public static RemoteAccount create(String id,
-				       Map<String, Object> credentials) {
+	public static RemoteAccount create(String id,
+					   Map<String, Object> credentials) {
 
-        return new RemoteAccount(id, credentials);
-    }
+		return new RemoteAccount(id, credentials);
+	}
 
-    public Map<String, Object> getUserDataMap() {
-        return userDataMap;
-    }
+	public Map<String, Object> getUserDataMap() {
+		return userDataMap;
+	}
 
+	@Override
+	public String toString() {
+		final StringBuilder tmp = new StringBuilder();
+		tmp.append(super.toString());
+		tmp.append("userDataMap");
+		tmp.append("{");
+		for (Map.Entry<String, Object> entry : userDataMap.entrySet()) {
+			tmp.append(entry.getKey());
+			tmp.append("=");
+			tmp.append(entry.getValue().toString());
+			tmp.append(",");
+		}
+		tmp.append("}");
+		return tmp.toString();
+	}
 }

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
@@ -49,948 +49,967 @@ import java.util.stream.Collectors;
  */
 public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 
-    private static final String LISTING_URL = "/listings";
-    private static final String PURCHAISNG_URL = "/purchases";
-    private final Account account;
+	private static final String LISTING_URL = "/listings";
+	private static final String PURCHAISNG_URL = "/purchases";
+	private final RemoteAccount account;
 
-    /**
-     * Creates a RemoteAgent with the specified Ocean connection and DID
-     *
-     * @param ocean Ocean connection to use
-     * @param did   DID for this agent
-     */
-    protected RemoteAgent(Ocean ocean, DID did, Account account) {
-        super(ocean, did);
-        this.account = (account == null) ? defaultAccount() : account;
-    }
+	/**
+	 * Creates a RemoteAgent with the specified Ocean connection and DID
+	 *
+	 * @param ocean Ocean connection to use
+	 * @param did   DID for this agent
+	 */
+	protected RemoteAgent(Ocean ocean, DID did, RemoteAccount account) {
+		super(ocean, did);
+		this.account = (account == null) ? defaultAccount() : account;
+		String token = getToken();
+		if (token == null) {
+			System.out.println("creating a token...");
+			token = createToken(this.account);
+		}
+		System.out.println("token: " + token);
+	}
 
-    /**
-     * Creates a RemoteAgent with the specified Ocean connection and DID
-     *
-     * @param ocean Ocean connection to use
-     * @param did   DID for this agent
-     * @return RemoteAgent
-     */
-    public static RemoteAgent create(Ocean ocean, DID did) {
-        return new RemoteAgent(ocean, did, null);
-    }
+	/**
+	 * Creates a RemoteAgent with the specified Ocean connection, DID
+	 * and RemoteAccount
+	 *
+	 * @param ocean Ocean connection to use
+	 * @param did   DID for this agent
+	 * @param account RemoteAccount for this agent
+	 * @return RemoteAgent
+	 */
+	public static RemoteAgent create(Ocean ocean, DID did, RemoteAccount account) {
+		return new RemoteAgent(ocean, did, account);
+	}
 
-    /**
-     * Creates a RemoteAgent with the specified Ocean connection, DID
-     * and Account
-     *
-     * @param ocean Ocean connection to use
-     * @param did   DID for this agent
-     * @param account Account for this agent
-     * @return RemoteAgent
-     */
-    public static RemoteAgent create(Ocean ocean, DID did, Account account) {
-        return new RemoteAgent(ocean, did, account);
-    }
+	/**
+	 * Creates a RemoteAgent with the specified Ocean connection and DID
+	 *
+	 * @param ocean Ocean connection to use
+	 * @param did   DID for this agent
+	 * @return RemoteAgent
+	 */
+	public static RemoteAgent create(Ocean ocean, DID did) {
+		return new RemoteAgent(ocean, did, null);
+	}
 
-    private Account defaultAccount() {
-	 RemoteAccount account = new RemoteAccount(Utils.createRandomHexString(32), null);
-	account.setCredential("username", "test");
-	account.setCredential("password", "foobar");
-	return account;
-    }
+	// for debugging only
+	private RemoteAccount defaultAccount() {
+		RemoteAccount account = RemoteAccount.create(Utils.createRandomHexString(32), null);
+		account.setCredential("username", "test");
+		account.setCredential("password", "foobar");
+		return account;
+	}
 
-    /**
-     * Invokes request on this RemoteAgent
-     *
-     * @param agent    the remote
-     * @param response
-     * @return Job for this request
-     * @throws RuntimeException for protocol errors
-     */
-    private static Job createJobWith200(RemoteAgent agent, HttpResponse response) {
-        HttpEntity entity = response.getEntity();
-        if (entity == null) throw new RuntimeException("Invoke failed: no response body");
-        try {
-            String body = Utils.stringFromStream(entity.getContent());
-            return RemoteJob.create(agent, body);
-        } catch (Exception e) {
-            throw new GenericException("Internal Server Error");
-        }
-    }
+	/**
+	 * Invokes request on this RemoteAgent
+	 *
+	 * @param agent    the remote
+	 * @param response
+	 * @return Job for this request
+	 * @throws RuntimeException for protocol errors
+	 */
+	private static Job createJobWith200(RemoteAgent agent, HttpResponse response) {
+		HttpEntity entity = response.getEntity();
+		if (entity == null) throw new RuntimeException("Invoke failed: no response body");
+		try {
+			String body = Utils.stringFromStream(entity.getContent());
+			return RemoteJob.create(agent, body);
+		} catch (Exception e) {
+			throw new GenericException("Internal Server Error");
+		}
+	}
 
-    /**
-     * Creates a remote invoke Job using the given HTTP response.
-     *
-     * @param agent    RemoteAgent on which to create the Job
-     * @param response A valid successful response from the remote Invoke API
-     * @return A job representing the remote invocation
-     * @throws IllegalArgumentException for a bad invoke request
-     * @throws RuntimeException         for protocol errors
-     */
-    public static Job createJob(RemoteAgent agent, HttpResponse response) {
-        StatusLine statusLine = response.getStatusLine();
-        int statusCode = statusLine.getStatusCode();
-        if (statusCode == 200) {
-            return RemoteAgent.createJobWith200(agent, response);
-        }
-        String reason = statusLine.getReasonPhrase();
-        if ((statusCode) == 400) {
-            throw new IllegalArgumentException("Bad invoke request: " + reason);
-        }
-        throw new GenericException("Internal Server Error");
-    }
+	/**
+	 * Creates a remote invoke Job using the given HTTP response.
+	 *
+	 * @param agent    RemoteAgent on which to create the Job
+	 * @param response A valid successful response from the remote Invoke API
+	 * @return A job representing the remote invocation
+	 * @throws IllegalArgumentException for a bad invoke request
+	 * @throws RuntimeException         for protocol errors
+	 */
+	public static Job createJob(RemoteAgent agent, HttpResponse response) {
+		StatusLine statusLine = response.getStatusLine();
+		int statusCode = statusLine.getStatusCode();
+		if (statusCode == 200) {
+			return RemoteAgent.createJobWith200(agent, response);
+		}
+		String reason = statusLine.getReasonPhrase();
+		if ((statusCode) == 400) {
+			throw new IllegalArgumentException("Bad invoke request: " + reason);
+		}
+		throw new GenericException("Internal Server Error");
+	}
 
-    public RemoteAgent connect(Account acc) {
-        // TODO: get user token and store this in account
-        return new RemoteAgent(ocean, did, acc);
-    }
+	public RemoteAgent connect(RemoteAccount acc) {
+		// TODO: get user token and store this in account
+		return new RemoteAgent(ocean, did, acc);
+	}
 
-    /**
-     * Registers Asset a with the RemoteAgent
-     *
-     * @param a Asset to register
-     * @return RemoteAsset corresponding to a
-     * @throws RemoteException  if a is not found
-     * @throws TODOException    for unhandled results
-     * @throws RuntimeException for protocol errors
-     */
-    @Override
-    public RemoteAsset registerAsset(Asset a) {
-        URI uri = getMetaURI();
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpPost httpPost = new HttpPost(uri);
-        addAuthHeaders(httpPost);
-        httpPost.setEntity(HTTP.textEntity(a.getMetadataString()));
-        CloseableHttpResponse response;
-        try {
-            response = httpclient.execute(httpPost);
-            try {
-                StatusLine statusLine = response.getStatusLine();
-                int statusCode = statusLine.getStatusCode();
-                if (statusCode == 404) {
-                    throw new RemoteException("Asset ID not found for at: " + uri);
-                }
-                if (statusCode == 200) {
-                    String body = Utils.stringFromStream(response.getEntity().getContent());
-                    String id = JSON.parse(body);
-                    return getAsset(id);
-                }
-                throw new TODOException("Result not handled: " + statusLine);
-            } finally {
-                response.close();
-            }
-        } catch (ClientProtocolException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-     }
+	/**
+	 * Registers Asset a with the RemoteAgent
+	 *
+	 * @param a Asset to register
+	 * @return RemoteAsset corresponding to a
+	 * @throws RemoteException  if a is not found
+	 * @throws TODOException    for unhandled results
+	 * @throws RuntimeException for protocol errors
+	 */
+	@Override
+	public RemoteAsset registerAsset(Asset a) {
+		URI uri = getMetaURI();
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		HttpPost httpPost = new HttpPost(uri);
+		addAuthHeaders(httpPost);
+		httpPost.setEntity(HTTP.textEntity(a.getMetadataString()));
+		CloseableHttpResponse response;
+		try {
+			response = httpclient.execute(httpPost);
+			try {
+				StatusLine statusLine = response.getStatusLine();
+				int statusCode = statusLine.getStatusCode();
+				if (statusCode == 404) {
+					throw new RemoteException("Asset ID not found for at: " + uri);
+				}
+				if (statusCode == 200) {
+					String body = Utils.stringFromStream(response.getEntity().getContent());
+					String id = JSON.parse(body);
+					return getAsset(id);
+				}
+				throw new TODOException("Result not handled: " + statusLine);
+			} finally {
+				response.close();
+			}
+		} catch (ClientProtocolException e) {
+			throw new RuntimeException(e);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
 	void addAuthHeaders(HttpRequest request) {
-		final CharArrayBuffer buffer = new CharArrayBuffer(32);
-		String token = null;
-
-		if (account.getCredentials().get("token") != null) {
-			token = account.getCredentials().get("token").toString();
-		}
-		if (token != null) {
-			buffer.append("token ");
-			buffer.append(token);
+		if (account == null) {
+			System.out.println("account = null");
 		} else {
-			String username = account.getCredentials().get("username").toString();
-			String password = account.getCredentials().get("password").toString();
-			final StringBuilder tmp = new StringBuilder();
-			tmp.append(username);
-			tmp.append(":");
-			tmp.append((password == null) ? "null" : password);
-			final Base64 base64codec = new Base64(0);
-			final byte[] base64password = base64codec.encode(EncodingUtils.getBytes(tmp.toString(), Consts.UTF_8.name()));
-			buffer.append("Basic ");
-			buffer.append(base64password, 0, base64password.length);
+			String token = null;
+			String username = null;
+			String password = null;
 
+			if (account.getUserDataMap().get("token") != null) {
+				token = account.getUserDataMap().get("token").toString();
+			}
+			if (account.getCredentials().get("username").toString() != null) {
+				username = account.getCredentials().get("username").toString();
+			}
+			if (account.getCredentials().get("password").toString() != null) {
+				password = account.getCredentials().get("password").toString();
+			}
+			if ((token == null) && (username == null)) {
+				System.out.println("account has no credentials");
+			} else {
+				final CharArrayBuffer buffer = new CharArrayBuffer(32);
+				if (token != null) {
+					buffer.append("token ");
+					buffer.append(token);
+				} else {
+					final StringBuilder tmp = new StringBuilder();
+					tmp.append(username);
+					tmp.append(":");
+					tmp.append((password == null) ? "null" : password);
+					final Base64 base64codec = new Base64(0);
+					final byte[] base64password = base64codec.encode(EncodingUtils.getBytes(tmp.toString(), Consts.UTF_8.name()));
+					buffer.append("Basic ");
+					buffer.append(base64password, 0, base64password.length);
+				}
+				String header = AUTH.WWW_AUTH_RESP;
+				String value = buffer.toString();
+				System.out.println("account = " + account);
+				System.out.println("RemoteAgent.addAuthHeaders(" + header + ", " + value + ")");
+				request.setHeader(header, value);
+			}
 		}
-		String header = AUTH.WWW_AUTH_RESP;
-		String value = buffer.toString();
-		// FIXME: remove this debugging
-		System.out.println("account = " + account);
-		System.out.println("RemoteAgent.addAuthHeaders(" + header + ", " + value + ")");
-		request.setHeader(header, value);
 	}
 
 
-    /**
-     * Gets an asset for the given asset ID from this agent.
-     * Returns Runtime Exception  if the asset ID does not exist.
-     *
-     * @param id The ID of the asset to get from this agent
-     * @return Asset The asset found
-     * @throws AuthorizationException if requestor does not have access permission
-     * @throws StorageException       if there is an error in retreiving the Asset
-     * @throws RemoteException        if there is a failure in a remote operation
-     * @throws TODOException          for unhandled status codes
-     */
-    @Override
-    public RemoteAsset getAsset(String id) {
-        URI uri = getMetaURI(id);
-        HttpGet httpget = new HttpGet(uri);
-        addAuthHeaders(httpget);
-        CloseableHttpResponse response = HTTP.execute(httpget);
-        try {
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            if (statusCode == 404) {
-                throw new RemoteException("Asset ID not found for at: " + uri);
-            } else if (statusCode == 200) {
-                String body = Utils.stringFromStream(HTTP.getContent(response));
-                // TODO: consider if this this an operation rather than data asset?
-                return RemoteAsset.create(this, body);
-            } else {
-                throw new TODOException("status code not handled: " + statusCode);
-            }
-        } finally {
-            HTTP.close(response);
-        }
-    }
-
-    /**
-     * API to check if the Asset is present if present it will return true else false.
-     *
-     * @param assetId
-     * @return
-     */
-    private boolean isAssetRegistered(String assetId) {
-        URI uri = getMetaURI(assetId);
-        HttpGet httpget = new HttpGet(uri);
-        addAuthHeaders(httpget);
-        CloseableHttpResponse response = HTTP.execute(httpget);
-        try {
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            return statusCode == 200;
-        } finally {
-            HTTP.close(response);
-        }
-    }
-
-    /**
-     * Uploads an asset to this agent. Registers the asset with the agent if required.
-     * <p>
-     * Throws an exception if upload is not possible, with the following likely causes:
-     * - The agent does not support uploads of this asset type / size
-     * - The data for the asset cannot be accessed by the agent
-     *
-     * @param a Asset to upload
-     * @return Asset An asset stored on the agent if the upload is successful
-     * @throws AuthorizationException if requestor does not have upload permission
-     * @throws StorageException       if there is an error in uploading the Asset
-     * @throws RemoteException        if there is an problem executing the task on remote Server.
-     */
-    @Override
-    public RemoteAsset uploadAsset(Asset a) {
-        RemoteAsset remoteAsset;
-
-        // asset alredy registered then only upload
-        if (isAssetRegistered(a.getAssetID())) {
-            remoteAsset = getAsset(a.getAssetID());
-            uploadAssetContent(a);
-        }
-        // if asset is not registered then registered and upload
-        else {
-            remoteAsset = registerAsset(a);
-            uploadAssetContent(a);
-        }
-
-        return remoteAsset;
-    }
-
-    /**
-     * API to uplaod the content of an Asset.
-     * API to upload the Asset content
-     *
-     * @param asset
-     * @return
-     */
-    private void uploadAssetContent(Asset asset) {
-        // get the storage API to upload the Asset content
-        URI uri = getStorageURI(asset.getAssetID());
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-
-        HttpPost post = new HttpPost(uri);
-        addAuthHeaders(post);
-        post.addHeader("Accept", "application/json");
-
-        InputStream assetContentAsStream = new ByteArrayInputStream(asset.getContent());
-        HttpEntity entity = HTTP.createMultiPart("file", new InputStreamBody(assetContentAsStream, Utils.createRandomHexString(16) + ".tmp"));
-
-        post.setEntity(entity);
-
-        CloseableHttpResponse response;
-        try {
-            response = httpclient.execute(post);
-            try {
-                StatusLine statusLine = response.getStatusLine();
-                int statusCode = statusLine.getStatusCode();
-                if (statusCode == 201) {
-                    return;
-                }
-                if (statusCode == 404) {
-                    throw new RemoteException("server could not find what was requested or it was configured not to fulfill the request." + uri);
-                } else if (statusCode == 500) {
-                    throw new GenericException("Internal Server Error : " + statusLine);
-                } else {
-                    throw new TODOException("Result not handled: " + statusLine);
-                }
-            } finally {
-                response.close();
-            }
-        } catch (ClientProtocolException e) {
-            throw new RemoteException("ClientProtocolException executing HTTP request ," + e.getMessage(), e);
-        } catch (IOException e) {
-            throw new RemoteException("IOException executing HTTP request ," + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Gets a URL string for accessing the specified asset ID
-     *
-     * @param id The asset ID to address
-     * @return The URL for the asset as a String
-     * @throws TODOException when not implemented yet
-     */
-    public String getAssetURL(String id) {
-        throw new TODOException();
-    }
-
-    /**
-     * Gets URI for this agent's invoke endpoint
-     *
-     * @return The URI for this agent's invoke endpoint
-     * @throws RuntimeException on URI syntax errors
-     */
-    public URI getInvokeURI() {
-        try {
-            return new URI(getInvokeEndpoint() + "/invokesync");
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Gets URI for this agent's endpoint for jobID
-     *
-     * @param jobID of the URI to create
-     * @return The URI for this agent's invoke endpoint
-     * @throws IllegalArgumentException on invalid URI for jobID
-     */
-    private URI getJobURI(String jobID) {
-        try {
-            return new URI(getInvokeEndpoint() + "/jobs/" + jobID);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Can't create valid URI for job: " + jobID, e);
-        }
-    }
-
-    /**
-     * Gets meta URI for this assetID
-     *
-     * @param assetID of the URI to create
-     * @return The URI for this assetID
-     * @throws UnsupportedOperationException if the agent does not support the Meta API
-     * @throws IllegalArgumentException      on invalid URI for assetID
-     */
-    private URI getMetaURI(String assetID) {
-        String metaEndpoint = getMetaEndpoint();
-        if (metaEndpoint == null)
-            throw new UnsupportedOperationException("This agent does not support the Meta API (no endpoint defined)");
-        try {
-            return new URI(metaEndpoint + "/data/" + assetID);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Can't create valid URI for asset metadata with ID: " + assetID, e);
-        }
-    }
-
-    /**
-     * Gets storage URI for this assetID
-     *
-     * @param assetID of the URI to create
-     * @return The URI for this assetID
-     * @throws UnsupportedOperationException if the agent does not support the Storage API
-     * @throws IllegalArgumentException      on invalid URI for assetID
-     */
-    public URI getStorageURI(String assetID) {
-        String storageEndpoint = getStorageEndpoint();
-        if (storageEndpoint == null) throw new UnsupportedOperationException(
-                "This agent does not support the Storage API (no endpoint defined)");
-        try {
-            return new URI(storageEndpoint + "/" + assetID);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Can't create valid URI for asset storage with ID: " + assetID, e);
-        }
-    }
-
-    /**
-     * Gets meta URI for this agent
-     *
-     * @return The URI for asset metadata
-     * @throws UnsupportedOperationException if the agent does not support the Meta API (no endpoint defined)
-     * @throws IllegalArgumentException      on invalid URI for asset metadata
-     */
-    private URI getMetaURI() {
-        String metaEndpoint = getMetaEndpoint();
-        if (metaEndpoint == null)
-            throw new UnsupportedOperationException("This agent does not support the Meta API (no endpoint defined)");
-        try {
-            return new URI(metaEndpoint + "/data");
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Can't create valid URI for asset metadata", e);
-        }
-    }
-
-    /**
-     * Gets URL for a given remoteAsset
-     *
-     * @param remoteAsset for the URL
-     * @return The URL for the remoteAsset
-     * @throws IllegalStateException No storage endpoint available for agent
-     * @throws Error                 on failure to get asset URL
-     */
-    public URL getURL(RemoteAsset remoteAsset) {
-        String storageEndpoint = getStorageEndpoint();
-        if (storageEndpoint == null) throw new IllegalStateException("No storage endpoint available for agent");
-        try {
-            return new URL(storageEndpoint + "/" + remoteAsset.getAssetID());
-        } catch (MalformedURLException e) {
-            throw new Error("Failed to get asset URL", e);
-        }
-    }
-
-    /**
-     * Gets the storage endpoint for this agent
-     *
-     * @return The storage endpoint for this agent e.g.
-     * "https://www.myagent.com/api/v1/storage"
-     */
-    public String getStorageEndpoint() {
-        return getEndpoint("Ocean.Storage.v1");
-    }
-
-    /**
-     * Gets the Invoke API endpoint for this agent
-     *
-     * @return The invoke endpoint for this agent e.g.
-     * "https://www.myagent.com/api/v1/invoke"
-     */
-    public String getInvokeEndpoint() {
-        return getEndpoint("Ocean.Invoke.v1");
-    }
-
-    /**
-     * Gets the Meta API endpoint for this agent, or null if this does not exist
-     *
-     * @return The Meta API endpoint for this agent e.g.
-     * "https://www.myagent.com/api/v1/meta"
-     */
-    public String getMetaEndpoint() {
-        return getEndpoint("Ocean.Meta.v1");
-    }
-
-    /**
-     * Gets the Market API endpoint for this agent, or null if this does not exist
-     *
-     * @return The Meta API endpoint for this agent e.g.
-     * "https://www.myagent.com/api/v1/meta"
-     */
-    public String getMarketEndpoint() {
-        return getEndpoint("Ocean.Market.v1");
-    }
-
-    /**
-     * Gets the Auth API endpoint for this agent, or null if this does not exist
-     *
-     * @return The Meta API endpoint for this agent e.g.
-     * "https://www.myagent.com/api/v1/meta"
-     */
-    public String getAuthEndpoint() {
-        return getEndpoint("Ocean.Auth.v1");
-    }
-
-    @Override
-    public Job invoke(Operation operation, Asset... params) {
-        Map<String, Object> request = new HashMap<String, Object>(2);
-        request.put("operation", operation.getAssetID());
-        request.put("params", Params.formatParams(operation, params));
-        return invoke(request);
-    }
-
-    /**
-     * Polls this agent for the Asset resulting from the given job ID
-     *
-     * @param jobID ID for the Job to poll
-     * @return The asset resulting from this job ID if available, null otherwise.
-     * @throws IllegalArgumentException If the job ID is invalid
-     * @throws RemoteException          if there is a failure in a remote operation
-     * @throws TODOException            for unhandled status codes
-     * @throws RuntimeException         for protocol errors
-     */
-    public Asset pollJob(String jobID) {
-        URI uri = getJobURI(jobID);
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpGet httpget = new HttpGet(uri);
-        CloseableHttpResponse response;
-        try {
-            response = httpclient.execute(httpget);
-            try {
-                StatusLine statusLine = response.getStatusLine();
-                int statusCode = statusLine.getStatusCode();
-                if (statusCode == 404) {
-                    throw new RemoteException("Job ID not found for invoke at: " + uri);
-                }
-                if (statusCode == 200) {
-                    String body = Utils.stringFromStream(response.getEntity().getContent());
-                    Map<String, Object> result = JSON.toMap(body);
-                    String status = (String) result.get("status");
-                    if (status == null) throw new RemoteException("No status in job result: " + body);
-                    if (status.equals("started") || status.equals("inprogress")) {
-                        return null; // no result yet
-                    }
-                    if (status.equals("complete")) {
-                        String assetID = (String) result.get("result");
-                        if (assetID == null) throw new RemoteException("No asset in completed job result: " + body);
-                        return RemoteAsset.create(this, assetID);
-                    }
-                }
-                throw new TODOException("status code not handled: " + statusCode);
-            } finally {
-                response.close();
-            }
-        } catch (ClientProtocolException e) {
-            throw new JobFailedException(" Client Protocol Expectopn :", e);
-        } catch (IOException e) {
-            throw new JobFailedException(" IOException occured  Expectopn :", e);
-        }
-    }
-
-    @Override
-    public Job invoke(Operation operation, Map<String, Asset> params) {
-        Map<String, Object> request = new HashMap<String, Object>(2);
-        request.put("operation", operation.getAssetID());
-        request.put("params", Params.formatParams(operation, params));
-        return invoke(request);
-    }
-
-    /**
-     * Invokes request on this RemoteAgent
-     *
-     * @param request Invoke request
-     * @return Job for this request
-     * @throws RuntimeException for protocol errors
-     */
-    private Job invoke(Map<String, Object> request) {
-        String req = JSON.toString(request);
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpPost httppost = new HttpPost(getInvokeURI());
-        StringEntity entity = new StringEntity(req, StandardCharsets.UTF_8);
-        httppost.setEntity(entity);
-        CloseableHttpResponse response;
-        try {
-            response = httpclient.execute(httppost);
-            try {
-                return RemoteAgent.createJob(this, response);
-            } finally {
-                response.close();
-            }
-        } catch (ClientProtocolException e) {
-            throw new JobFailedException(" Client Protocol Expectopn :", e);
-        } catch (IOException e) {
-            throw new JobFailedException(" IOException occured  Expectopn :", e);
-        }
-    }
-
-    /**
-     * API for Listing
-     *
-     * @param marketAgentUrl
-     * @return
-     */
-    private List<Map<String, Object>> getAllMarketMetaData(String marketAgentUrl) {
-        URI uri = getMarketLURI(marketAgentUrl);
-        HttpGet httpget = new HttpGet(uri);
-        addAuthHeaders(httpget);
-        CloseableHttpResponse response = HTTP.execute(httpget);
-        List<Map<String, Object>> result;
-
-        try {
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            if (statusCode == 404) {
-                throw new RemoteException("Listing ID not found for at: " + statusCode);
-            } else if (statusCode == 200) {
-                String body = Utils.stringFromStream(HTTP.getContent(response));
-                try {
-                    result =
-                            new ObjectMapper().readValue(body, List.class);
-
-                    return result;
-
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            } else {
-                throw new TODOException("status code not handled: " + statusCode);
-            }
-        } finally {
-            HTTP.close(response);
-        }
-        return Collections.emptyList();
-    }
-
-    private String createMarketAgentInstance(Map<String, Object> listingData, String marketAgentUrl) {
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpPost httpPost = new HttpPost(getMarketLURI(marketAgentUrl));
-
-        addAuthHeaders(httpPost);
-        httpPost.addHeader("Accept", "application/json");
-
-        httpPost.setEntity(new StringEntity(JSON.toPrettyString(listingData), ContentType.APPLICATION_JSON));
-
-        CloseableHttpResponse response = null;
-        try {
-            response = httpclient.execute(httpPost);
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            if (statusCode == 200) {
-                String body = Utils.stringFromStream(HTTP.getContent(response));
-                return body;
-            } else if (statusCode == 403) {
-                throw new TODOException("Can't modify listing: only listing owner can do so" + statusCode);
-            } else {
-                throw new TODOException("status code not handled: " + statusCode);
-            }
-        } catch (ClientProtocolException e) {
-            throw new JobFailedException(" Client Protocol Expectopn :", e);
-        } catch (IOException e) {
-            throw new JobFailedException(" IOException occured  Expectopn :", e);
-        } finally {
-            HTTP.close(response);
-        }
-    }
-
-    private String getMarketMetaData(String marketAgentUrl) {
-        HttpGet httpget = new HttpGet(getMarketLURI(marketAgentUrl));
-        addAuthHeaders(httpget);
-        CloseableHttpResponse response = HTTP.execute(httpget);
-        try {
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            if (statusCode == 404) {
-                throw new RemoteException("Asset ID not found for at: " + statusCode);
-            } else if (statusCode == 200) {
-                String body = Utils.stringFromStream(HTTP.getContent(response));
-                return body;
-            } else {
-                throw new TODOException("status code not handled: " + statusCode);
-            }
-        } finally {
-            HTTP.close(response);
-        }
-    }
-
-    private String updateMarketMetaData(Map<String, Object> listingData, String marketAgentUrl) {
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpPut put = new HttpPut(getMarketLURI(marketAgentUrl));
-
-        addAuthHeaders(put);
-        put.addHeader("Accept", "application/json");
-
-        put.setEntity(new StringEntity(JSON.toPrettyString(listingData), ContentType.APPLICATION_JSON));
-
-        CloseableHttpResponse response = null;
-        try {
-            response = httpclient.execute(put);
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            if (statusCode == 200) {
-                String body = Utils.stringFromStream(HTTP.getContent(response));
-                return body;
-            } else if (statusCode == 403) {
-                throw new TODOException("Can't modify listing: only listing owner can do so" + statusCode);
-            } else {
-                throw new TODOException("status code not handled: " + statusCode);
-            }
-        } catch (ClientProtocolException e) {
-            throw new JobFailedException(" Client Protocol Expectopn :", e);
-        } catch (IOException e) {
-            throw new JobFailedException(" IOException occured  Expectopn :", e);
-        } finally {
-            HTTP.close(response);
-        }
-    }
-
-    /**
-     * Gets market URI for this agent
-     *
-     * @return The URI for listing metadata
-     * @throws UnsupportedOperationException if the agent does not support the Meta API (no endpoint defined)
-     * @throws IllegalArgumentException      on invalid URI for asset metadata
-     */
-    private URI getMarketLURI(String marketAgentUrl) {
-        String marketEndpoint = getMarketEndpoint();
-        if (marketEndpoint == null)
-            throw new UnsupportedOperationException("This agent does not support the Market API (no endpoint defined)");
-        try {
-            return new URI(marketEndpoint + marketAgentUrl);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Can't create valid URI for asset metadata", e);
-        }
-    }
-
-    @Override
-    public Listing getListing(String id) {
-        return RemoteListing.create(this, id);
-    }
-
-    @Override
-    public Purchase getPurchasing(String id) {
-        return RemotePurchase.create(this, id);
-    }
-
-    @Override
-    public Listing createListing(Map<String, Object> listingData) {
-        String response = createMarketAgentInstance(listingData, LISTING_URL);
-        String id = JSON.toMap(response).get("id").toString();
-        return RemoteListing.create(this, id);
-    }
-
-    /**
-     * API to update the Lising data
-     *
-     * @param newValue
-     * @return
-     */
-    public Listing updateListing(Map<String, Object> newValue) {
-
-        String id = newValue.get("id").toString();
-        if (id == null) {
-            throw new GenericException("Listing ID not found");
-        }
-        updateMarketMetaData(newValue, LISTING_URL + "/" + id);
-        return RemoteListing.create(this, id);
-
-    }
-
-    /**
-     * API to get the listing meta data
-     *
-     * @param id
-     * @return
-     */
-    public Map<String, Object> getListingMetaData(String id) {
-        String response = getMarketMetaData(LISTING_URL + "/" + id);
-        return JSON.toMap(response);
-    }
-
-    /**
-     * API to get all listing metaData.It may ab very heavy call .
-     *
-     * @return
-     */
-    public List<Listing> getAllListing() {
-
-        List<Map<String, Object>> result = getAllMarketMetaData(LISTING_URL);
-
-        return result.stream()
-                .map(p -> RemoteListing.create(this, p.get("id").toString()))
-                .collect(Collectors.toList());
-
-    }
-
-    /**
-     * APi to get listing by userID
-     *
-     * @param userID
-     * @return
-     */
-    public List<RemoteListing> getAllListing(String userID) {
-
-        List<Map<String, Object>> result = getAllMarketMetaData(LISTING_URL);
-
-        return result.stream()
-                .map(p -> RemoteListing.create(this, p.get("id").toString()))
-                .collect(Collectors.toList());
-
-    }
-
-    /**
-     * API to create the Purchase object
-     *
-     * @param data
-     * @return
-     */
-    public Purchase createPurchase(Map<String, Object> data) {
-        String response = createMarketAgentInstance(data, PURCHAISNG_URL);
-        String id = JSON.toMap(response).get("id").toString();
-        return RemotePurchase.create(this, id);
-    }
-
-    /**
-     * API to get the Purchase MetaData
-     *
-     * @param id
-     * @return
-     */
-    public Map<String, Object> getPurchaseMetaData(String id) {
-        String response = getMarketMetaData(PURCHAISNG_URL + "/" + id);
-        return JSON.toMap(response);
-    }
-
-    /**
-     * API to update the Purchase
-     *
-     * @param newValue
-     * @return
-     */
-    public Purchase updatePurchase(Map<String, Object> newValue) {
-
-        String id = newValue.get("id").toString();
-        if (id == null) {
-            throw new GenericException("Listing ID not found");
-        }
-        updateMarketMetaData(newValue, PURCHAISNG_URL + "/" + id);
-        return RemotePurchase.create(this, id);
-
-    }
-
-    /**
-     * Gets Auth URI for this agent
-     *
-     * @return The URI for listing metadata
-     * @throws UnsupportedOperationException if the agent does not support the Meta API (no endpoint defined)
-     * @throws IllegalArgumentException      on invalid URI for asset metadata
-     */
-    private URI getAuthURI(String authpath) {
-        String authEndpoint = getAuthEndpoint();
-        if (authEndpoint == null)
-            throw new UnsupportedOperationException("This agent does not support the Market API (no endpoint defined)");
-        try {
-            return new URI(authEndpoint + "/" + authpath);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Can't create valid URI for asset metadata", e);
-        }
-    }
-
-    /**
-     * API to get the logged in user details from the Agent
-     *
-     * @return
-     */
-    public Map<String, Object> getUserDetails() {
-
-        HttpGet httpget = new HttpGet(getAuthURI("user"));
-        addAuthHeaders(httpget);
-        CloseableHttpResponse response = HTTP.execute(httpget);
-        try {
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            if (statusCode == 404) {
-                throw new RemoteException("Auth not found for at: " + statusCode);
-            } else if (statusCode == 200) {
-                String body = Utils.stringFromStream(HTTP.getContent(response));
-                ((RemoteAccount) account).getUserDataMap().putAll(JSON.toMap(body));
-                return JSON.toMap(body);
-            } else {
-                throw new TODOException("status code not handled: " + statusCode);
-            }
-        } finally {
-            HTTP.close(response);
-        }
-
-    }
-
-    /**
-     * API to get the Oath Token from the Agent
-     *
-     * @return
-     */
-    public String getToken() {
-
-        HttpGet httpget = new HttpGet(getAuthURI("token"));
-        addAuthHeaders(httpget);
-        CloseableHttpResponse response = HTTP.execute(httpget);
-        try {
-            StatusLine statusLine = response.getStatusLine();
-            int statusCode = statusLine.getStatusCode();
-            if (statusCode == 404) {
-                throw new RemoteException("Asset ID not found for at: " + statusCode);
-            } else if (statusCode == 200) {
-                String body = Utils.stringFromStream(HTTP.getContent(response));
-                List<String> allTokenLst = JSON.parse(body);
-                ((RemoteAccount) account).getUserDataMap().put("token", allTokenLst.get(0));
-                return allTokenLst.get(0);
-            } else {
-                throw new TODOException("status code not handled: " + statusCode);
-            }
-        } finally {
-            HTTP.close(response);
-        }
-
-
-    }
-
-    /**
-     * The will create the token base on user name and password configured
-     *
-     * @return new token
-     */
-    public String createToken(Account account) {
-        String url = "token";
-        HttpPost httpPost = new HttpPost(getAuthURI(url));
-        CloseableHttpResponse response;
-        try {
-            String username = account.getCredentials().get("username").toString();
-            String password = account.getCredentials().get("password").toString();
-
-            response = HTTP.executeWithAuth(httpPost, username, password);
-            try {
-                StatusLine statusLine = response.getStatusLine();
-                int statusCode = statusLine.getStatusCode();
-                if (statusCode == 404) {
-                    throw new RemoteException("Asset ID not found for at: " + "");
-                }
-                if (statusCode == 200) {
-                    String body = Utils.stringFromStream(response.getEntity().getContent());
-                    String id = JSON.parse(body);
-                    updateAccountData(id);
-                    return id;
-                }
-                throw new TODOException("Result not handled: " + statusLine);
-            } finally {
-                response.close();
-            }
-        } catch (ClientProtocolException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-    }
-
-    /**
-     * API to update the Account Data based on response received from the Agent
-     *
-     *
-     * @param token
-     */
-    private void updateAccountData(String token) {
-        if (null == account) {
-            return;
-        }
-
-
-        if (null != ((RemoteAccount) account).getUserDataMap().get("token")) {
-            List<String> tokenLst = ((List<String>) ((RemoteAccount) account).getUserDataMap().get("token"));
-            tokenLst.add(token);
-        } else {
-            List<String> tokenLst = new ArrayList<>();
-            tokenLst.add(token);
-            ((RemoteAccount) account).getUserDataMap().put("token", tokenLst);
-        }
-
-    }
+	/**
+	 * Gets an asset for the given asset ID from this agent.
+	 * Returns Runtime Exception  if the asset ID does not exist.
+	 *
+	 * @param id The ID of the asset to get from this agent
+	 * @return Asset The asset found
+	 * @throws AuthorizationException if requestor does not have access permission
+	 * @throws StorageException       if there is an error in retreiving the Asset
+	 * @throws RemoteException        if there is a failure in a remote operation
+	 * @throws TODOException          for unhandled status codes
+	 */
+	@Override
+	public RemoteAsset getAsset(String id) {
+		URI uri = getMetaURI(id);
+		HttpGet httpget = new HttpGet(uri);
+		addAuthHeaders(httpget);
+		CloseableHttpResponse response = HTTP.execute(httpget);
+		try {
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			if (statusCode == 404) {
+				throw new RemoteException("Asset ID not found for at: " + uri);
+			} else if (statusCode == 200) {
+				String body = Utils.stringFromStream(HTTP.getContent(response));
+				// TODO: consider if this this an operation rather than data asset?
+				return RemoteAsset.create(this, body);
+			} else {
+				throw new TODOException("status code not handled: " + statusCode);
+			}
+		} finally {
+			HTTP.close(response);
+		}
+	}
+
+	/**
+	 * API to check if the Asset is present if present it will return true else false.
+	 *
+	 * @param assetId
+	 * @return
+	 */
+	private boolean isAssetRegistered(String assetId) {
+		URI uri = getMetaURI(assetId);
+		HttpGet httpget = new HttpGet(uri);
+		addAuthHeaders(httpget);
+		CloseableHttpResponse response = HTTP.execute(httpget);
+		try {
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			return statusCode == 200;
+		} finally {
+			HTTP.close(response);
+		}
+	}
+
+	/**
+	 * Uploads an asset to this agent. Registers the asset with the agent if required.
+	 * <p>
+	 * Throws an exception if upload is not possible, with the following likely causes:
+	 * - The agent does not support uploads of this asset type / size
+	 * - The data for the asset cannot be accessed by the agent
+	 *
+	 * @param a Asset to upload
+	 * @return Asset An asset stored on the agent if the upload is successful
+	 * @throws AuthorizationException if requestor does not have upload permission
+	 * @throws StorageException       if there is an error in uploading the Asset
+	 * @throws RemoteException        if there is an problem executing the task on remote Server.
+	 */
+	@Override
+	public RemoteAsset uploadAsset(Asset a) {
+		RemoteAsset remoteAsset;
+
+		// asset alredy registered then only upload
+		if (isAssetRegistered(a.getAssetID())) {
+			remoteAsset = getAsset(a.getAssetID());
+			uploadAssetContent(a);
+		}
+		// if asset is not registered then registered and upload
+		else {
+			remoteAsset = registerAsset(a);
+			uploadAssetContent(a);
+		}
+
+		return remoteAsset;
+	}
+
+	/**
+	 * API to uplaod the content of an Asset.
+	 * API to upload the Asset content
+	 *
+	 * @param asset
+	 * @return
+	 */
+	private void uploadAssetContent(Asset asset) {
+		// get the storage API to upload the Asset content
+		URI uri = getStorageURI(asset.getAssetID());
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+
+		HttpPost post = new HttpPost(uri);
+		addAuthHeaders(post);
+		post.addHeader("Accept", "application/json");
+
+		InputStream assetContentAsStream = new ByteArrayInputStream(asset.getContent());
+		HttpEntity entity = HTTP.createMultiPart("file", new InputStreamBody(assetContentAsStream, Utils.createRandomHexString(16) + ".tmp"));
+
+		post.setEntity(entity);
+
+		CloseableHttpResponse response;
+		try {
+			response = httpclient.execute(post);
+			try {
+				StatusLine statusLine = response.getStatusLine();
+				int statusCode = statusLine.getStatusCode();
+				if (statusCode == 201) {
+					return;
+				}
+				if (statusCode == 404) {
+					throw new RemoteException("server could not find what was requested or it was configured not to fulfill the request." + uri);
+				} else if (statusCode == 500) {
+					throw new GenericException("Internal Server Error : " + statusLine);
+				} else {
+					throw new TODOException("Result not handled: " + statusLine);
+				}
+			} finally {
+				response.close();
+			}
+		} catch (ClientProtocolException e) {
+			throw new RemoteException("ClientProtocolException executing HTTP request ," + e.getMessage(), e);
+		} catch (IOException e) {
+			throw new RemoteException("IOException executing HTTP request ," + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Gets a URL string for accessing the specified asset ID
+	 *
+	 * @param id The asset ID to address
+	 * @return The URL for the asset as a String
+	 * @throws TODOException when not implemented yet
+	 */
+	public String getAssetURL(String id) {
+		throw new TODOException();
+	}
+
+	/**
+	 * Gets URI for this agent's invoke endpoint
+	 *
+	 * @return The URI for this agent's invoke endpoint
+	 * @throws RuntimeException on URI syntax errors
+	 */
+	public URI getInvokeURI() {
+		try {
+			return new URI(getInvokeEndpoint() + "/invokesync");
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Gets URI for this agent's endpoint for jobID
+	 *
+	 * @param jobID of the URI to create
+	 * @return The URI for this agent's invoke endpoint
+	 * @throws IllegalArgumentException on invalid URI for jobID
+	 */
+	private URI getJobURI(String jobID) {
+		try {
+			return new URI(getInvokeEndpoint() + "/jobs/" + jobID);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Can't create valid URI for job: " + jobID, e);
+		}
+	}
+
+	/**
+	 * Gets meta URI for this assetID
+	 *
+	 * @param assetID of the URI to create
+	 * @return The URI for this assetID
+	 * @throws UnsupportedOperationException if the agent does not support the Meta API
+	 * @throws IllegalArgumentException      on invalid URI for assetID
+	 */
+	private URI getMetaURI(String assetID) {
+		String metaEndpoint = getMetaEndpoint();
+		if (metaEndpoint == null)
+			throw new UnsupportedOperationException("This agent does not support the Meta API (no endpoint defined)");
+		try {
+			return new URI(metaEndpoint + "/data/" + assetID);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Can't create valid URI for asset metadata with ID: " + assetID, e);
+		}
+	}
+
+	/**
+	 * Gets storage URI for this assetID
+	 *
+	 * @param assetID of the URI to create
+	 * @return The URI for this assetID
+	 * @throws UnsupportedOperationException if the agent does not support the Storage API
+	 * @throws IllegalArgumentException      on invalid URI for assetID
+	 */
+	public URI getStorageURI(String assetID) {
+		String storageEndpoint = getStorageEndpoint();
+		if (storageEndpoint == null) throw new UnsupportedOperationException(
+										     "This agent does not support the Storage API (no endpoint defined)");
+		try {
+			return new URI(storageEndpoint + "/" + assetID);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Can't create valid URI for asset storage with ID: " + assetID, e);
+		}
+	}
+
+	/**
+	 * Gets meta URI for this agent
+	 *
+	 * @return The URI for asset metadata
+	 * @throws UnsupportedOperationException if the agent does not support the Meta API (no endpoint defined)
+	 * @throws IllegalArgumentException      on invalid URI for asset metadata
+	 */
+	private URI getMetaURI() {
+		String metaEndpoint = getMetaEndpoint();
+		if (metaEndpoint == null)
+			throw new UnsupportedOperationException("This agent does not support the Meta API (no endpoint defined)");
+		try {
+			return new URI(metaEndpoint + "/data");
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Can't create valid URI for asset metadata", e);
+		}
+	}
+
+	/**
+	 * Gets URL for a given remoteAsset
+	 *
+	 * @param remoteAsset for the URL
+	 * @return The URL for the remoteAsset
+	 * @throws IllegalStateException No storage endpoint available for agent
+	 * @throws Error                 on failure to get asset URL
+	 */
+	public URL getURL(RemoteAsset remoteAsset) {
+		String storageEndpoint = getStorageEndpoint();
+		if (storageEndpoint == null) throw new IllegalStateException("No storage endpoint available for agent");
+		try {
+			return new URL(storageEndpoint + "/" + remoteAsset.getAssetID());
+		} catch (MalformedURLException e) {
+			throw new Error("Failed to get asset URL", e);
+		}
+	}
+
+	/**
+	 * Gets the storage endpoint for this agent
+	 *
+	 * @return The storage endpoint for this agent e.g.
+	 * "https://www.myagent.com/api/v1/storage"
+	 */
+	public String getStorageEndpoint() {
+		return getEndpoint("Ocean.Storage.v1");
+	}
+
+	/**
+	 * Gets the Invoke API endpoint for this agent
+	 *
+	 * @return The invoke endpoint for this agent e.g.
+	 * "https://www.myagent.com/api/v1/invoke"
+	 */
+	public String getInvokeEndpoint() {
+		return getEndpoint("Ocean.Invoke.v1");
+	}
+
+	/**
+	 * Gets the Meta API endpoint for this agent, or null if this does not exist
+	 *
+	 * @return The Meta API endpoint for this agent e.g.
+	 * "https://www.myagent.com/api/v1/meta"
+	 */
+	public String getMetaEndpoint() {
+		return getEndpoint("Ocean.Meta.v1");
+	}
+
+	/**
+	 * Gets the Market API endpoint for this agent, or null if this does not exist
+	 *
+	 * @return The Meta API endpoint for this agent e.g.
+	 * "https://www.myagent.com/api/v1/meta"
+	 */
+	public String getMarketEndpoint() {
+		return getEndpoint("Ocean.Market.v1");
+	}
+
+	/**
+	 * Gets the Auth API endpoint for this agent, or null if this does not exist
+	 *
+	 * @return The Meta API endpoint for this agent e.g.
+	 * "https://www.myagent.com/api/v1/meta"
+	 */
+	public String getAuthEndpoint() {
+		return getEndpoint("Ocean.Auth.v1");
+	}
+
+	@Override
+	public Job invoke(Operation operation, Asset... params) {
+		Map<String, Object> request = new HashMap<String, Object>(2);
+		request.put("operation", operation.getAssetID());
+		request.put("params", Params.formatParams(operation, params));
+		return invoke(request);
+	}
+
+	/**
+	 * Polls this agent for the Asset resulting from the given job ID
+	 *
+	 * @param jobID ID for the Job to poll
+	 * @return The asset resulting from this job ID if available, null otherwise.
+	 * @throws IllegalArgumentException If the job ID is invalid
+	 * @throws RemoteException          if there is a failure in a remote operation
+	 * @throws TODOException            for unhandled status codes
+	 * @throws RuntimeException         for protocol errors
+	 */
+	public Asset pollJob(String jobID) {
+		URI uri = getJobURI(jobID);
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		HttpGet httpget = new HttpGet(uri);
+		CloseableHttpResponse response;
+		try {
+			response = httpclient.execute(httpget);
+			try {
+				StatusLine statusLine = response.getStatusLine();
+				int statusCode = statusLine.getStatusCode();
+				if (statusCode == 404) {
+					throw new RemoteException("Job ID not found for invoke at: " + uri);
+				}
+				if (statusCode == 200) {
+					String body = Utils.stringFromStream(response.getEntity().getContent());
+					Map<String, Object> result = JSON.toMap(body);
+					String status = (String) result.get("status");
+					if (status == null) throw new RemoteException("No status in job result: " + body);
+					if (status.equals("started") || status.equals("inprogress")) {
+						return null; // no result yet
+					}
+					if (status.equals("complete")) {
+						String assetID = (String) result.get("result");
+						if (assetID == null) throw new RemoteException("No asset in completed job result: " + body);
+						return RemoteAsset.create(this, assetID);
+					}
+				}
+				throw new TODOException("status code not handled: " + statusCode);
+			} finally {
+				response.close();
+			}
+		} catch (ClientProtocolException e) {
+			throw new JobFailedException(" Client Protocol Expectopn :", e);
+		} catch (IOException e) {
+			throw new JobFailedException(" IOException occured  Expectopn :", e);
+		}
+	}
+
+	@Override
+	public Job invoke(Operation operation, Map<String, Asset> params) {
+		Map<String, Object> request = new HashMap<String, Object>(2);
+		request.put("operation", operation.getAssetID());
+		request.put("params", Params.formatParams(operation, params));
+		return invoke(request);
+	}
+
+	/**
+	 * Invokes request on this RemoteAgent
+	 *
+	 * @param request Invoke request
+	 * @return Job for this request
+	 * @throws RuntimeException for protocol errors
+	 */
+	private Job invoke(Map<String, Object> request) {
+		String req = JSON.toString(request);
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		HttpPost httppost = new HttpPost(getInvokeURI());
+		StringEntity entity = new StringEntity(req, StandardCharsets.UTF_8);
+		httppost.setEntity(entity);
+		CloseableHttpResponse response;
+		try {
+			response = httpclient.execute(httppost);
+			try {
+				return RemoteAgent.createJob(this, response);
+			} finally {
+				response.close();
+			}
+		} catch (ClientProtocolException e) {
+			throw new JobFailedException(" Client Protocol Expectopn :", e);
+		} catch (IOException e) {
+			throw new JobFailedException(" IOException occured  Expectopn :", e);
+		}
+	}
+
+	/**
+	 * API for Listing
+	 *
+	 * @param marketAgentUrl
+	 * @return
+	 */
+	private List<Map<String, Object>> getAllMarketMetaData(String marketAgentUrl) {
+		URI uri = getMarketLURI(marketAgentUrl);
+		HttpGet httpget = new HttpGet(uri);
+		addAuthHeaders(httpget);
+		CloseableHttpResponse response = HTTP.execute(httpget);
+		List<Map<String, Object>> result;
+
+		try {
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			if (statusCode == 404) {
+				throw new RemoteException("Listing ID not found for at: " + statusCode);
+			} else if (statusCode == 200) {
+				String body = Utils.stringFromStream(HTTP.getContent(response));
+				try {
+					result =
+						new ObjectMapper().readValue(body, List.class);
+
+					return result;
+
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			} else {
+				throw new TODOException("status code not handled: " + statusCode);
+			}
+		} finally {
+			HTTP.close(response);
+		}
+		return Collections.emptyList();
+	}
+
+	private String createMarketAgentInstance(Map<String, Object> listingData, String marketAgentUrl) {
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		HttpPost httpPost = new HttpPost(getMarketLURI(marketAgentUrl));
+
+		addAuthHeaders(httpPost);
+		httpPost.addHeader("Accept", "application/json");
+
+		httpPost.setEntity(new StringEntity(JSON.toPrettyString(listingData), ContentType.APPLICATION_JSON));
+
+		CloseableHttpResponse response = null;
+		try {
+			response = httpclient.execute(httpPost);
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			if (statusCode == 200) {
+				String body = Utils.stringFromStream(HTTP.getContent(response));
+				return body;
+			} else if (statusCode == 403) {
+				throw new TODOException("Can't modify listing: only listing owner can do so" + statusCode);
+			} else {
+				throw new TODOException("status code not handled: " + statusCode);
+			}
+		} catch (ClientProtocolException e) {
+			throw new JobFailedException(" Client Protocol Expectopn :", e);
+		} catch (IOException e) {
+			throw new JobFailedException(" IOException occured  Expectopn :", e);
+		} finally {
+			HTTP.close(response);
+		}
+	}
+
+	private String getMarketMetaData(String marketAgentUrl) {
+		HttpGet httpget = new HttpGet(getMarketLURI(marketAgentUrl));
+		addAuthHeaders(httpget);
+		CloseableHttpResponse response = HTTP.execute(httpget);
+		try {
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			if (statusCode == 404) {
+				throw new RemoteException("Asset ID not found for at: " + statusCode);
+			} else if (statusCode == 200) {
+				String body = Utils.stringFromStream(HTTP.getContent(response));
+				return body;
+			} else {
+				throw new TODOException("status code not handled: " + statusCode);
+			}
+		} finally {
+			HTTP.close(response);
+		}
+	}
+
+	private String updateMarketMetaData(Map<String, Object> listingData, String marketAgentUrl) {
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		HttpPut put = new HttpPut(getMarketLURI(marketAgentUrl));
+
+		addAuthHeaders(put);
+		put.addHeader("Accept", "application/json");
+
+		put.setEntity(new StringEntity(JSON.toPrettyString(listingData), ContentType.APPLICATION_JSON));
+
+		CloseableHttpResponse response = null;
+		try {
+			response = httpclient.execute(put);
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			if (statusCode == 200) {
+				String body = Utils.stringFromStream(HTTP.getContent(response));
+				return body;
+			} else if (statusCode == 403) {
+				throw new TODOException("Can't modify listing: only listing owner can do so" + statusCode);
+			} else {
+				throw new TODOException("status code not handled: " + statusCode);
+			}
+		} catch (ClientProtocolException e) {
+			throw new JobFailedException(" Client Protocol Expectopn :", e);
+		} catch (IOException e) {
+			throw new JobFailedException(" IOException occured  Expectopn :", e);
+		} finally {
+			HTTP.close(response);
+		}
+	}
+
+	/**
+	 * Gets market URI for this agent
+	 *
+	 * @return The URI for listing metadata
+	 * @throws UnsupportedOperationException if the agent does not support the Meta API (no endpoint defined)
+	 * @throws IllegalArgumentException      on invalid URI for asset metadata
+	 */
+	private URI getMarketLURI(String marketAgentUrl) {
+		String marketEndpoint = getMarketEndpoint();
+		if (marketEndpoint == null)
+			throw new UnsupportedOperationException("This agent does not support the Market API (no endpoint defined)");
+		try {
+			return new URI(marketEndpoint + marketAgentUrl);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Can't create valid URI for asset metadata", e);
+		}
+	}
+
+	@Override
+	public Listing getListing(String id) {
+		return RemoteListing.create(this, id);
+	}
+
+	@Override
+	public Purchase getPurchasing(String id) {
+		return RemotePurchase.create(this, id);
+	}
+
+	@Override
+	public Listing createListing(Map<String, Object> listingData) {
+		String response = createMarketAgentInstance(listingData, LISTING_URL);
+		String id = JSON.toMap(response).get("id").toString();
+		return RemoteListing.create(this, id);
+	}
+
+	/**
+	 * API to update the Lising data
+	 *
+	 * @param newValue
+	 * @return
+	 */
+	public Listing updateListing(Map<String, Object> newValue) {
+
+		String id = newValue.get("id").toString();
+		if (id == null) {
+			throw new GenericException("Listing ID not found");
+		}
+		updateMarketMetaData(newValue, LISTING_URL + "/" + id);
+		return RemoteListing.create(this, id);
+
+	}
+
+	/**
+	 * API to get the listing meta data
+	 *
+	 * @param id
+	 * @return
+	 */
+	public Map<String, Object> getListingMetaData(String id) {
+		String response = getMarketMetaData(LISTING_URL + "/" + id);
+		return JSON.toMap(response);
+	}
+
+	/**
+	 * API to get all listing metaData.It may ab very heavy call .
+	 *
+	 * @return
+	 */
+	public List<Listing> getAllListing() {
+
+		List<Map<String, Object>> result = getAllMarketMetaData(LISTING_URL);
+
+		return result.stream()
+			.map(p -> RemoteListing.create(this, p.get("id").toString()))
+			.collect(Collectors.toList());
+
+	}
+
+	/**
+	 * APi to get listing by userID
+	 *
+	 * @param userID
+	 * @return
+	 */
+	public List<RemoteListing> getAllListing(String userID) {
+
+		List<Map<String, Object>> result = getAllMarketMetaData(LISTING_URL);
+
+		return result.stream()
+			.map(p -> RemoteListing.create(this, p.get("id").toString()))
+			.collect(Collectors.toList());
+
+	}
+
+	/**
+	 * API to create the Purchase object
+	 *
+	 * @param data
+	 * @return
+	 */
+	public Purchase createPurchase(Map<String, Object> data) {
+		String response = createMarketAgentInstance(data, PURCHAISNG_URL);
+		String id = JSON.toMap(response).get("id").toString();
+		return RemotePurchase.create(this, id);
+	}
+
+	/**
+	 * API to get the Purchase MetaData
+	 *
+	 * @param id
+	 * @return
+	 */
+	public Map<String, Object> getPurchaseMetaData(String id) {
+		String response = getMarketMetaData(PURCHAISNG_URL + "/" + id);
+		return JSON.toMap(response);
+	}
+
+	/**
+	 * API to update the Purchase
+	 *
+	 * @param newValue
+	 * @return
+	 */
+	public Purchase updatePurchase(Map<String, Object> newValue) {
+
+		String id = newValue.get("id").toString();
+		if (id == null) {
+			throw new GenericException("Listing ID not found");
+		}
+		updateMarketMetaData(newValue, PURCHAISNG_URL + "/" + id);
+		return RemotePurchase.create(this, id);
+
+	}
+
+	/**
+	 * Gets Auth URI for this agent
+	 *
+	 * @return The URI for listing metadata
+	 * @throws UnsupportedOperationException if the agent does not support the Meta API (no endpoint defined)
+	 * @throws IllegalArgumentException      on invalid URI for asset metadata
+	 */
+	private URI getAuthURI(String authpath) {
+		String authEndpoint = getAuthEndpoint();
+		if (authEndpoint == null)
+			throw new UnsupportedOperationException("This agent does not support the Market API (no endpoint defined)");
+		try {
+			return new URI(authEndpoint + "/" + authpath);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Can't create valid URI for asset metadata", e);
+		}
+	}
+
+	/**
+	 * API to get the logged in user details from the Agent
+	 *
+	 * @return
+	 */
+	public Map<String, Object> getUserDetails() {
+
+		HttpGet httpget = new HttpGet(getAuthURI("user"));
+		addAuthHeaders(httpget);
+		CloseableHttpResponse response = HTTP.execute(httpget);
+		try {
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			if (statusCode == 404) {
+				throw new RemoteException("Auth not found for at: " + statusCode);
+			} else if (statusCode == 200) {
+				String body = Utils.stringFromStream(HTTP.getContent(response));
+				account.getUserDataMap().putAll(JSON.toMap(body));
+				return JSON.toMap(body);
+			} else {
+				throw new TODOException("status code not handled: " + statusCode);
+			}
+		} finally {
+			HTTP.close(response);
+		}
+
+	}
+
+	/**
+	 * API to get the Oath Token from the Agent
+	 *
+	 * @return
+	 */
+	public String getToken() {
+		HttpGet httpget = new HttpGet(getAuthURI("token"));
+		addAuthHeaders(httpget);
+		CloseableHttpResponse response = HTTP.execute(httpget);
+		try {
+			StatusLine statusLine = response.getStatusLine();
+			int statusCode = statusLine.getStatusCode();
+			if (statusCode == 404) {
+				throw new RemoteException("Asset ID not found for at: " + statusCode);
+			} else if (statusCode == 200) {
+				String body = Utils.stringFromStream(HTTP.getContent(response));
+				List<String> allTokenLst = JSON.parse(body);
+				// NOTE: only save the first one, NOT the entire list!
+				account.getUserDataMap().put("token", allTokenLst.get(0));
+				return allTokenLst.get(0);
+			} else {
+				throw new TODOException("status code not handled: " + statusCode);
+			}
+		} finally {
+			HTTP.close(response);
+		}
+
+
+	}
+
+	/**
+	 * The will create the token base on user name and password configured
+	 *
+	 * @return new token
+	 */
+	public String createToken(RemoteAccount account) {
+		String url = "token";
+		HttpPost httpPost = new HttpPost(getAuthURI(url));
+		CloseableHttpResponse response;
+		try {
+			String username = account.getCredentials().get("username").toString();
+			String password = account.getCredentials().get("password").toString();
+
+			response = HTTP.executeWithAuth(httpPost, username, password);
+			try {
+				StatusLine statusLine = response.getStatusLine();
+				int statusCode = statusLine.getStatusCode();
+				if (statusCode == 404) {
+					throw new RemoteException("Asset ID not found for at: " + "");
+				}
+				if (statusCode == 200) {
+					String body = Utils.stringFromStream(response.getEntity().getContent());
+					String id = JSON.parse(body);
+					updateAccountData(id);
+					return id;
+				}
+				throw new TODOException("Result not handled: " + statusLine);
+			} finally {
+				response.close();
+			}
+		} catch (ClientProtocolException e) {
+			throw new RuntimeException(e);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+
+	/**
+	 * API to update the Account Data based on response received from the Agent
+	 *
+	 *
+	 * @param token
+	 */
+	private void updateAccountData(String token) {
+		if (null == account) {
+			return;
+		}
+		account.getUserDataMap().put("token", token);
+		/* if we keep a list of tokens...
+		if (null != account.getUserDataMap().get("token")) {
+			List<String> tokenLst = ((List<String>) account.getUserDataMap().get("token"));
+			tokenLst.add(token);
+		} else {
+			List<String> tokenLst = new ArrayList<>();
+			tokenLst.add(token);
+			account.getUserDataMap().put("token", tokenLst);
+		}
+		*/
+	}
 
 }

--- a/src/main/java/sg/dex/starfish/impl/remote/Surfer.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/Surfer.java
@@ -13,34 +13,34 @@ import java.util.Map;
 public class Surfer {
 
 	public static RemoteAgent getSurfer(String host) {
-	    Map<String, Object> ddo = new HashMap<>();
-	    List<Map<String, Object>> services = new ArrayList<>();
-	    services.add(Utils.mapOf(
-	            "type", "Ocean.Meta.v1",
-	            "serviceEndpoint", host + "/api/v1/meta"));
-	    services.add(Utils.mapOf(
-	            "type", "Ocean.Storage.v1",
-	            "serviceEndpoint", host + "/api/v1/assets"));
-	    services.add(Utils.mapOf(
-	            "type", "Ocean.Invoke.v1",
-	            "serviceEndpoint", host + "/api/v1/invoke"));
-	    services.add(Utils.mapOf(
-	            "type", "Ocean.Market.v1",
-	            "serviceEndpoint", host + "/api/v1/market"));
-        services.add(Utils.mapOf(
-                "type", "Ocean.Auth.v1",
-                "serviceEndpoint", host + "/api/v1/auth"));
-	    ddo.put("service", services);
-	    String ddoString = JSON.toPrettyString(ddo);
-	    // System.out.println(ddoString);
-	
-	    Ocean ocean = Ocean.connect();
-	    DID surferDID = DID.createRandom();
-	    ocean.registerLocalDID(surferDID, ddoString);
+		Map<String, Object> ddo = new HashMap<>();
+		List<Map<String, Object>> services = new ArrayList<>();
+		services.add(Utils.mapOf(
+					 "type", "Ocean.Meta.v1",
+					 "serviceEndpoint", host + "/api/v1/meta"));
+		services.add(Utils.mapOf(
+					 "type", "Ocean.Storage.v1",
+					 "serviceEndpoint", host + "/api/v1/assets"));
+		services.add(Utils.mapOf(
+					 "type", "Ocean.Invoke.v1",
+					 "serviceEndpoint", host + "/api/v1/invoke"));
+		services.add(Utils.mapOf(
+					 "type", "Ocean.Market.v1",
+					 "serviceEndpoint", host + "/api/v1/market"));
+		services.add(Utils.mapOf(
+					 "type", "Ocean.Auth.v1",
+					 "serviceEndpoint", host + "/api/v1/auth"));
+		ddo.put("service", services);
+		String ddoString = JSON.toPrettyString(ddo);
+		// System.out.println(ddoString);
 
-	    RemoteAgent surfer = RemoteAgent.create(ocean, surferDID);
+		Ocean ocean = Ocean.connect();
+		DID surferDID = DID.createRandom();
+		ocean.registerLocalDID(surferDID, ddoString);
 
-	    return surfer;
+		RemoteAgent surfer = RemoteAgent.create(ocean, surferDID);
+
+		return surfer;
 	}
 
 }

--- a/src/main/java/sg/dex/starfish/impl/squid/SquidAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/squid/SquidAgent.java
@@ -10,12 +10,23 @@ import sg.dex.starfish.impl.AAgent;
 import sg.dex.starfish.util.DID;
 import sg.dex.starfish.exception.AuthorizationException;
 import sg.dex.starfish.exception.StorageException;
+import sg.dex.starfish.impl.remote.RemoteAsset;
+import sg.dex.starfish.impl.remote.RemoteAgent;
 
 import com.oceanprotocol.squid.api.OceanAPI;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import com.oceanprotocol.squid.models.Account;
 import com.oceanprotocol.squid.models.Balance;
 import com.oceanprotocol.squid.exceptions.EthereumException;
+
+/* DESIGN CONSIDERATION
+   It may be more apropos for SquidAgent to be a subclass of RemoteAgent.
+   In this case the constructor would need to pass an Account
+   to the superclass.
+   If so then the signatures of registerAsset, getAsset, uploadAsset
+   would need to change to return a RemoteAsset and
+   SquidAsset would need to be a subclass of RemoteAsset.
+*/
 
 /**
  * Class implementing a Squid Agent

--- a/src/test/java/sg/dex/starfish/samples/AuthSample.java
+++ b/src/test/java/sg/dex/starfish/samples/AuthSample.java
@@ -28,7 +28,7 @@ public class AuthSample {
     }
 
 
-    public static void main(String[] arg) {
+    public static void main(String... args) {
         Properties properties = getProperties();
         String ip = properties.getProperty("surfer.host");
         String port = properties.getProperty("surfer.port");
@@ -38,7 +38,7 @@ public class AuthSample {
         // credential
         Map<String, Object> credentialMap = new HashMap<>();
         credentialMap.put("username", "Aladdin");
-        credentialMap.put("password", "6e29fef5d289293d");
+        credentialMap.put("password", "OpenSesame");
 
         // creating remote Account
         RemoteAccount surferAccount = RemoteAccount.create("9671e2c4dabf1b0ea4f4db909b9df3814ca481e3d110072e0e7d776774a68e0d",
@@ -63,8 +63,8 @@ public class AuthSample {
 
 
         // get ALL Tokens
-        String allTokensLst = surfer.getToken();
-        assertNotNull(allTokensLst);
+        String firstToken = surfer.getToken();
+        assertNotNull(firstToken);
 
 
         String token = surferAccount.getUserDataMap().get("token").toString();
@@ -76,7 +76,8 @@ public class AuthSample {
         Object metaData = surferAccount.getUserDataMap().get("metadata");
         String status = surferAccount.getUserDataMap().get("status").toString();
 
-        List<String> role = (List<String>) surferAccount.getUserDataMap().get("roles");
+        // List<String> role = (List<String>) surferAccount.getUserDataMap().get("roles");
+        String role = surferAccount.getUserDataMap().get("roles").toString();
 
         assertNotNull(id);
         assertNotNull(metaData);
@@ -89,4 +90,3 @@ public class AuthSample {
 
 
 }
-

--- a/src/test/java/sg/dex/starfish/samples/SampleIntegrationTests.java
+++ b/src/test/java/sg/dex/starfish/samples/SampleIntegrationTests.java
@@ -13,6 +13,17 @@ public class SampleIntegrationTests {
 	private static boolean surferUp = Utils.checkURL(DEFAULT_SURFER_URL);
 	private static String registerAssetID = null;
 
+
+	@Test
+	public void aAuthSample() {
+		System.out.println("=== aAuthSample ===");
+		if (surferUp) {
+			AuthSample.main();
+		} else {
+			System.out.println("WARNING: not tested as surfer is not up.");
+		}
+	}
+
 	@Test
 	public void aTestInvokeSample() {
 		System.out.println("=== aTestInvokeSample ===");
@@ -48,5 +59,4 @@ public class SampleIntegrationTests {
 			System.out.println("WARNING: not tested as surfer is not up.");
 		}
 	}
-
 }


### PR DESCRIPTION
Properly uses Account to encode Basic Authentication

NOTE: needs to re-based

TODO
- Set RemoteAccount credentials at Surfer creation time (test)
- Use Basic Auth once to get (or create) an OAuth2 token
- Add OAuth2 token to Account credentials
- Update addAuthHeaders() to prefer OAuth2 token, if present
- Remove RemoteAgent.defaultAccount()
- Verify all call paths to addAuthHeaders()

Signed-off-by: Tom Marble <tmarble@info9.net>