### PR TITLE
fix javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
 			<artifactId>httpmime</artifactId>
 			<version>4.5.8</version>
 		</dependency>
+		<dependency>
+			<groupId>com.typesafe</groupId>
+			<artifactId>config</artifactId>
+			<version>1.3.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -151,6 +156,16 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+				<version>3.7.1</version>
+				<configuration>
+					<failOnError>false</failOnError>
+				</configuration>
+			</plugin>
+
 		</plugins>
 
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,21 @@
 			<artifactId>httpmime</artifactId>
 			<version>4.5.8</version>
 		</dependency>
-		<dependency>
-			<groupId>com.typesafe</groupId>
-			<artifactId>config</artifactId>
-			<version>1.3.4</version>
-		</dependency>
 	</dependencies>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.1</version>
+				<configuration>
+				  <show>public</show>
+                                  <failOnError>false</failOnError>
+				</configuration>
+			</plugin>
+		</plugins>
+</reporting>
 
 	<build>
 		<plugins>
@@ -108,17 +117,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
 				<version>2.5.3</version>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.1</version>
-				<configuration>
-					<additionalparam>-Xdoclint:none</additionalparam>
-					<failOnError>false</failOnError>
-					<skip>true</skip>
-				</configuration>
 			</plugin>
 
 			<plugin>
@@ -156,6 +154,19 @@
 					</execution>
 				</executions>
 			</plugin>
+
+                        <plugin>
+                          <groupId>org.apache.maven.plugins</groupId>
+                          <artifactId>maven-project-info-reports-plugin</artifactId>
+			  <version>3.0.0</version>
+                        </plugin>
+
+                        <plugin>
+                          <groupId>org.apache.felix</groupId>
+                          <artifactId>maven-bundle-plugin</artifactId>
+			  <version>4.2.0</version>
+                          <extensions>true</extensions>
+                        </plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/scripts/deployDocs.sh
+++ b/scripts/deployDocs.sh
@@ -31,7 +31,7 @@ echo "building docs package $PACKAGE_NAME"
 
 # make the docs from source
 rm -rf target/site
-mvn site
+mvn site || true # do NOT fail due to javadoc failure
 
 # package into a tar.gz file for deployment
 (cd "$DOC_PATH"; tar -czf "../../$DEPLOY_FILENAME" ./)

--- a/src/main/java/sg/dex/starfish/Asset.java
+++ b/src/main/java/sg/dex/starfish/Asset.java
@@ -18,8 +18,8 @@ public interface Asset {
 
 	/**
 	 * Gets DID for this Asset
-	 * @see <a href="https://w3c-ccg.github.io/did-spec"></a>
-	 *See {@linktourl https://w3c-ccg.github.io/did-spec/}
+	 * @see <a href="https://w3c-ccg.github.io/did-spec">W3C DID spec</a>
+	 *
 	 * @throws UnsupportedOperationException if unable to obtain DID
 	 * @return the assetID
 	 */
@@ -28,8 +28,8 @@ public interface Asset {
 	/**
 	 * Gets the Ocean DID for this asset. The DID may include a DID path to specify
 	 * the precise asset if the DID refers to an agent managing the asset.
-	 * @see <a href="https://w3c-ccg.github.io/did-spec"></a>
 	 * Throws an exception if a DID is not available or cannot be constructed.
+	 * @see <a href="https://w3c-ccg.github.io/did-spec">W3C DID spec</a>
 	 *
 	 * @return The global DID for this asset.
 	 */
@@ -37,9 +37,9 @@ public interface Asset {
 
 	/**
 	 * Gets a copy of the JSON metadata for this asset, as a map of strings to values.
-	 * 
+	 *
 	 * Asset metadata will differ as per type of asset: (e.g. dataset, operation, bundle)
-	 * 
+	 *
 	 * @return New clone of the parsed JSON metadata for this asset
 	 */
 	public Map<String, Object> getMetadata();
@@ -75,9 +75,9 @@ public interface Asset {
 	}
 
 	/**
-	 * Returns the metadata for this asset as a String. Assets should store their metadata by deafult 
+	 * Returns the metadata for this asset as a String. Assets should store their metadata by deafult
 	 * as a valid JSON string.
-	 * 
+	 *
 	 * Warning: Some implementations may not validate the JSON on asset creation and it is possible
 	 * for the metadata String to contain invalid JSON.
 	 *
@@ -87,7 +87,7 @@ public interface Asset {
 
 	/**
 	 * Gets the contents of this data asset as a byte[] array.
-	 * 
+	 *
 	 * @throws UnsupportedOperationException If this asset does not support getting byte data
 	 * @throws AuthorizationException if requestor does not have access permission
 	 * @throws StorageException if unable to load the Asset
@@ -103,7 +103,7 @@ public interface Asset {
 	 * @return A map representing this asset
 	 */
 	public Map<String, Object> getParamValue();
-	
+
 	/**
 	 * Tests if this asset is an bundle, i.e. can contain sub-assets.
 	 *

--- a/src/main/java/sg/dex/starfish/impl/AAccount.java
+++ b/src/main/java/sg/dex/starfish/impl/AAccount.java
@@ -47,10 +47,10 @@ public abstract class AAccount implements Account {
 	 * Required credentials are defined by the agent implementation, but would typically include
 	 * things like user name, password etc.
 	 *
-	 * @return Map<String,Object> credentials
+	 * @return credentials
 	 */
         @Override
-	public Map<String,Object>p getCredentials() {
+	public Map<String,Object> getCredentials() {
 		// deep cloning the map
 		return  credentials.entrySet().stream()
 			.collect(Collectors.toMap(e -> e.getKey(),

--- a/src/main/java/sg/dex/starfish/impl/AAccount.java
+++ b/src/main/java/sg/dex/starfish/impl/AAccount.java
@@ -47,10 +47,10 @@ public abstract class AAccount implements Account {
 	 * Required credentials are defined by the agent implementation, but would typically include
 	 * things like user name, password etc.
 	 *
-	 * @return
+	 * @return Map<String,Object> credentials
 	 */
         @Override
-	public Map<String,Object> getCredentials() {
+	public Map<String,Object>p getCredentials() {
 		// deep cloning the map
 		return  credentials.entrySet().stream()
 			.collect(Collectors.toMap(e -> e.getKey(),

--- a/src/main/java/sg/dex/starfish/impl/AIdentity.java
+++ b/src/main/java/sg/dex/starfish/impl/AIdentity.java
@@ -40,7 +40,7 @@ public abstract class AIdentity implements Identity {
 	/**
 	 * Gets the Accounts associated with this Identity
 	 * where the key is the Account.getID();
-	 * @return
+n	 * @return Map<String,Account> accounts
 	 */
 	@Override
 	public Map<String,Account> getAccounts() {

--- a/src/main/java/sg/dex/starfish/impl/AIdentity.java
+++ b/src/main/java/sg/dex/starfish/impl/AIdentity.java
@@ -40,7 +40,7 @@ public abstract class AIdentity implements Identity {
 	/**
 	 * Gets the Accounts associated with this Identity
 	 * where the key is the Account.getID();
-n	 * @return Map<String,Account> accounts
+	 * @return accounts
 	 */
 	@Override
 	public Map<String,Account> getAccounts() {

--- a/src/main/java/sg/dex/starfish/impl/file/FileAsset.java
+++ b/src/main/java/sg/dex/starfish/impl/file/FileAsset.java
@@ -35,7 +35,7 @@ public class FileAsset extends AAsset {
 	/**
 	 * Create a FileAsset to read from an existing file
 	 * @param f
-	 * @return
+	 * @return FileAsset
 	 */
 	public static FileAsset create(File f) {
 		return new FileAsset(buildMetadata(f,null),f);
@@ -45,7 +45,7 @@ public class FileAsset extends AAsset {
 	 * Create a new FileAsset at the given file location, using the specified asset as a source.
 	 * @param f
 	 * @param source
-	 * @return
+	 * @return FileAsset
 	 */
 	public static FileAsset create(File f, Asset source) {
 		throw new TODOException("Create file asset on disk");

--- a/src/main/java/sg/dex/starfish/impl/memory/MemoryAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/memory/MemoryAgent.java
@@ -17,7 +17,7 @@ import java.util.concurrent.Executors;
 
 /**
  * An in-memory agent implementation
- * 
+ *
  * @author Mike
  */
 public class MemoryAgent extends AAgent implements Invokable, MarketAgent {
@@ -39,7 +39,7 @@ public class MemoryAgent extends AAgent implements Invokable, MarketAgent {
 
     /**
      * Creates a new MemoryAgent with the given DID
-     * 
+     *
      * @param did DID for this agent
      * @return A MemoryAgent with the given DID
      */
@@ -49,7 +49,7 @@ public class MemoryAgent extends AAgent implements Invokable, MarketAgent {
 
     /**
      * Creates a new MemoryAgent with a randomised DID
-     * 
+     *
      * @return A MemoryAgent with the given DID
      */
     public static MemoryAgent create() {
@@ -58,7 +58,7 @@ public class MemoryAgent extends AAgent implements Invokable, MarketAgent {
 
     /**
      * Creates a new MemoryAgent with the given DID
-     * 
+     *
      * @param did DID for this agent
      * @return A MemoryAgent with the given DID
      */
@@ -210,7 +210,7 @@ public class MemoryAgent extends AAgent implements Invokable, MarketAgent {
      * API to get the Purchase instance
      *
      * @param purchaseData
-     * @return
+     * @return MemoryPurchase
      */
     public MemoryPurchase createPurchase(Map<String, Object> purchaseData) {
         if (purchaseData.get("listingid") == null) {
@@ -227,7 +227,7 @@ public class MemoryAgent extends AAgent implements Invokable, MarketAgent {
      * API to create a response similar to Remote Agents responses.
      *
      * @param purchaseData
-     * @return
+     * @return Map<String, Object> responseMetaDataPurchase
      */
     private Map<String, Object> getResponseMetaDataPurchase(Map<String, Object> purchaseData) {
 

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
@@ -803,8 +803,8 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to get the listing meta data
 	 *
 	 * @param id
-	 * @return Map<String, Object> metadata
-n	 */
+	 * @return metadata
+	 */
 	public Map<String, Object> getListingMetaData(String id) {
 		String response = getMarketMetaData(LISTING_URL + "/" + id);
 		return JSON.toMap(response);
@@ -857,7 +857,7 @@ n	 */
 	 * API to get the Purchase MetaData
 	 *
 	 * @param id
-	 * @return Map<String, Object> purchaseMetadata
+	 * @return purchaseMetadata
 	 */
 	public Map<String, Object> getPurchaseMetaData(String id) {
 		String response = getMarketMetaData(PURCHASE_URL + "/" + id);
@@ -902,7 +902,7 @@ n	 */
 	/**
 	 * API to get the logged in user details from the Agent
 	 *
-	 * @return Map<String, Object> userDetails
+	 * @return userDetails
 	 */
 	public Map<String, Object> getUserDetails() {
 

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
@@ -268,7 +268,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 			HTTP.close(response);
 		}
 	}
-	
+
 	@Override
 	public Asset getAsset(DID did) {
 		return getAsset(did.getID());
@@ -278,7 +278,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to check if the Asset is present if present it will return true else false.
 	 *
 	 * @param assetId
-	 * @return
+	 * @return boolean
 	 */
 	private boolean isAssetRegistered(String assetId) {
 		URI uri = getMetaURI(assetId);
@@ -330,7 +330,6 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to upload the Asset content
 	 *
 	 * @param asset
-	 * @return
 	 */
 	private void uploadAssetContent(Asset asset) {
 		// get the storage API to upload the Asset content
@@ -632,7 +631,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API for Listing
 	 *
 	 * @param marketAgentUrl
-	 * @return
+	 * @return List<Map<String, Object>> marketMetaData
 	 */
 	private List<Map<String, Object>> getAllMarketMetaData(String marketAgentUrl) {
 		URI uri = getMarketLURI(marketAgentUrl);
@@ -787,7 +786,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to update the Lising data
 	 *
 	 * @param newValue
-	 * @return
+	 * @return Listing
 	 */
 	public Listing updateListing(Map<String, Object> newValue) {
 
@@ -804,8 +803,8 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to get the listing meta data
 	 *
 	 * @param id
-	 * @return
-	 */
+	 * @return Map<String, Object> metadata
+n	 */
 	public Map<String, Object> getListingMetaData(String id) {
 		String response = getMarketMetaData(LISTING_URL + "/" + id);
 		return JSON.toMap(response);
@@ -814,7 +813,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	/**
 	 * API to get all listing metaData.It may ab very heavy call .
 	 *
-	 * @return
+	 * @return List<Listing>
 	 */
 	public List<Listing> getAllListing() {
 
@@ -830,7 +829,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * APi to get listing by userID
 	 *
 	 * @param userID
-	 * @return
+	 * @return List<RemoteListing> listing
 	 */
 	public List<RemoteListing> getAllListing(String userID) {
 
@@ -846,7 +845,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to create the Purchase object
 	 *
 	 * @param data
-	 * @return
+	 * @return Purchase
 	 */
 	public Purchase createPurchase(Map<String, Object> data) {
 		String response = createMarketAgentInstance(data, PURCHASE_URL);
@@ -858,7 +857,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to get the Purchase MetaData
 	 *
 	 * @param id
-	 * @return
+	 * @return Map<String, Object> purchaseMetadata
 	 */
 	public Map<String, Object> getPurchaseMetaData(String id) {
 		String response = getMarketMetaData(PURCHASE_URL + "/" + id);
@@ -869,7 +868,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	 * API to update the Purchase
 	 *
 	 * @param newValue
-	 * @return
+	 * @return Purchase
 	 */
 	public Purchase updatePurchase(Map<String, Object> newValue) {
 
@@ -903,7 +902,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
 	/**
 	 * API to get the logged in user details from the Agent
 	 *
-	 * @return
+	 * @return Map<String, Object> userDetails
 	 */
 	public Map<String, Object> getUserDetails() {
 

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteBundle.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteBundle.java
@@ -32,7 +32,7 @@ public class RemoteBundle extends ARemoteAsset implements Bundle {
      * API to create a Remote bundle asset asset with given Bundle name
      *
      * @param assetMap map of all asset with name and assetID
-     * @return
+     * @return RemoteBundle
      */
     public static RemoteBundle create(RemoteAgent remoteAgent, Map<String, Asset> assetMap, Map<String, Object> meta) {
 
@@ -56,7 +56,7 @@ public class RemoteBundle extends ARemoteAsset implements Bundle {
      * API to create a Remote bundle asset asset with given Bundle name
      *
      * @param assetMap map of all asset with name and assetID
-     * @return
+     * @return RemoteBundle
      */
     public static RemoteBundle create(RemoteAgent remoteAgent, Map<String, Asset> assetMap) {
 
@@ -79,7 +79,7 @@ public class RemoteBundle extends ARemoteAsset implements Bundle {
      * API to create a Remote bundle asset asset with given Bundle name
      *
      * @param assetMap map of all asset with name and assetID
-     * @return
+     * @return RemoteBundle
      */
     public static RemoteBundle create(Map<String, Asset> assetMap) {
 
@@ -102,7 +102,7 @@ public class RemoteBundle extends ARemoteAsset implements Bundle {
      * API to create a Remote bundle asset asset with given Bundle name
      *
      * @param assetMap map of all asset with name and assetID
-     * @return
+     * @return RemoteBundle
      */
     public static RemoteBundle create(Map<String, Asset> assetMap, Map<String, Object> meta) {
 
@@ -142,7 +142,7 @@ public class RemoteBundle extends ARemoteAsset implements Bundle {
      * API to get the map of AssetID based on AssetId
      *
      * @param assetId
-     * @return
+     * @return Map<String, String> assetIdMap
      */
     private static Map<String, String> getAssetIdMap(String assetId) {
         Map<String, String> assetIDMap = new HashMap<>();

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteListing.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteListing.java
@@ -44,7 +44,7 @@ public class RemoteListing extends AListing {
      *
      * @param agent
      * @param id
-     * @return
+     * @return RemoteListing
      */
     public static RemoteListing create(RemoteAgent agent, String id) {
         RemoteListing remoteListing = new RemoteListing(agent, id);
@@ -105,7 +105,7 @@ public class RemoteListing extends AListing {
 
     /**
      * API to get the AssetID
-     * @return
+     * @return String assetId
      */
     private String getAssetId() {
         return getMetaData().get("assetid").toString();
@@ -113,7 +113,7 @@ public class RemoteListing extends AListing {
 
     /**
      * API to get the USer ID
-     * @return
+     * @return String userId
      */
     private String getUserId() {
         return getMetaData().get("userid").toString();
@@ -121,7 +121,7 @@ public class RemoteListing extends AListing {
 
     /**
      * API to get the Aggrement
-     * @return
+     * @return String agreement
      */
     private String getAggrement() {
         return getMetaData().get("agreement").toString();
@@ -129,7 +129,7 @@ public class RemoteListing extends AListing {
 
     /**
      * API to get the Listing ID
-     * @return
+     * @return String listingId
      */
     private String getListing_id() {
         return getMetaData().get("id").toString();

--- a/src/main/java/sg/dex/starfish/impl/remote/RemotePurchase.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemotePurchase.java
@@ -42,7 +42,7 @@ public class RemotePurchase implements Purchase {
      *
      * @param agent
      * @param id
-     * @return
+     * @return RemotePurchase
      */
     public static RemotePurchase create(RemoteAgent agent, String id) {
         RemotePurchase remotePurchase = new RemotePurchase(agent, id);

--- a/src/main/java/sg/dex/starfish/impl/url/ResourceAsset.java
+++ b/src/main/java/sg/dex/starfish/impl/url/ResourceAsset.java
@@ -36,7 +36,7 @@ public class ResourceAsset extends AAsset implements DataAsset {
      *
      * @param meta
      * @param resourcePath
-     * @return
+     * @return ResourceAsset
      */
     public static ResourceAsset create(String meta, String resourcePath) {
         return new ResourceAsset(meta, resourcePath);
@@ -46,7 +46,7 @@ public class ResourceAsset extends AAsset implements DataAsset {
      * API to crete a Resource Asset with resource Name
      *
      * @param resourceName
-     * @return
+     * @return ResourceAsset
      */
     public static ResourceAsset create(String resourceName) {
         return create(buildMetaData(resourceName, null), resourceName);
@@ -57,7 +57,7 @@ public class ResourceAsset extends AAsset implements DataAsset {
      *
      * @param resourcePath
      * @param meta
-     * @return
+     * @return String buildMetadata
      */
     private static String buildMetaData(String resourcePath, Map<String, Object> meta) {
         String hash = Hex.toString(Hash.keccak256(resourcePath));
@@ -100,7 +100,7 @@ public class ResourceAsset extends AAsset implements DataAsset {
     /**
      * API to get the name of the resource
      *
-     * @return
+     * @return String name
      */
     public String getName() {
         return resourceName;


### PR DESCRIPTION
should generate API docs, but NOT break the build

NOTE: there is an ugly stack trace which can be ignored, as in:
https://github.com/FasterXML/jackson-module-scala/issues/393
